### PR TITLE
Fix cmd options for cargo fmt command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Cargo build files
         uses: Leafwing-Studios/cargo-cache@v1.0.0
       - name: Run cargo fmt
-        run: cargo fmt --check --workspace --all-features
+        run: cargo fmt --check --all
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `--workspace` and `--all-features` options don't exist for the `cargo fmt` command, this was an oversight on my part.

I would also recommend to require the added CI jobs to pass before merging in the repository settings to ensure that we are maintaining clean code on the `main` branch :)