### PR TITLE
Pass thru markup error

### DIFF
--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -556,7 +556,7 @@ impl VirtualMachine {
         let substituted_text = expand_substitutions(&line_text, substitutions);
         let markup = self
             .parse_markup(&substituted_text)
-            .map_err(|e| DialogueError::MarkupParseError(e))?;
+            .map_err(DialogueError::MarkupParseError)?;
         let line = Line {
             id: string_id,
             text: markup.text,

--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -554,7 +554,9 @@ impl VirtualMachine {
             }
         })?;
         let substituted_text = expand_substitutions(&line_text, substitutions);
-        let markup = self.parse_markup(&substituted_text).unwrap();
+        let markup = self
+            .parse_markup(&substituted_text)
+            .map_err(|e| DialogueError::MarkupParseError(e))?;
         let line = Line {
             id: string_id,
             text: markup.text,


### PR DESCRIPTION
DialogueError has an error for markup parsing errors but we don't use it.