### PR TITLE
add get_headers_for_node

### DIFF
--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -312,6 +312,18 @@ impl Dialogue {
             .map(|node| node.tags)
     }
 
+    /// Returns the headers for the node `node_name`.
+    ///
+    /// The headers are all the key-value pairs defined in the node's source code
+    /// including the `tags` and `title` headers.
+    ///
+    /// Returns [`None`] if the node is not present in the program.
+    #[must_use]
+    pub fn get_headers_for_node(&self, node_name: &str) -> Option<Vec<Header>> {
+        self.get_node_logging_errors(node_name)
+            .map(|node| node.headers)
+    }
+
     /// Gets a value indicating whether a specified node exists in the [`Program`].
     #[must_use]
     pub fn node_exists(&self, node_name: &str) -> bool {

--- a/crates/yarnspinner/tests/dialogue_tests.rs
+++ b/crates/yarnspinner/tests/dialogue_tests.rs
@@ -6,6 +6,7 @@
 use test_base::prelude::*;
 use yarnspinner::compiler::*;
 use yarnspinner::runtime::*;
+use yarnspinner_core::prelude::Header;
 
 mod test_base;
 
@@ -160,6 +161,41 @@ fn test_getting_tags() {
     let tags = dialogue.get_tags_for_node("LearnMore").unwrap();
 
     assert_eq!(tags, vec!["rawText"]);
+}
+
+#[test]
+fn test_getting_headers() {
+    let path = test_data_path().join("Example.yarn");
+    let mut test_base = TestBase::new();
+
+    let result = Compiler::new().read_file(path).compile().unwrap();
+
+    test_base = test_base.with_program(result.program.unwrap());
+    let dialogue = &test_base.dialogue;
+
+    let headers = dialogue.get_headers_for_node("LearnMore").unwrap();
+
+    assert_eq!(
+        headers,
+        vec![
+            Header {
+                key: "title".to_string(),
+                value: "LearnMore".to_string()
+            },
+            Header {
+                key: "tags".to_string(),
+                value: "rawText".to_string()
+            },
+            Header {
+                key: "colorID".to_string(),
+                value: "0".to_string()
+            },
+            Header {
+                key: "position".to_string(),
+                value: "763,472".to_string()
+            }
+        ]
+    );
 }
 
 /// ## Implementation note


### PR DESCRIPTION
Hiyo, `dialogue` does not currently provide a way to access headers outside of plain "tags" so I thought this might be helpful.