### PR TITLE
Fix CI

### DIFF
--- a/crates/compiler/src/visitors/type_check_visitor.rs
+++ b/crates/compiler/src/visitors/type_check_visitor.rs
@@ -437,12 +437,8 @@ impl<'input> YarnSpinnerParserVisitorCompat<'input> for TypeCheckVisitor<'input>
     }
 
     fn visit_set_statement(&mut self, ctx: &Set_statementContext<'input>) -> Self::Return {
-        let Some(variable_context) = ctx.variable() else {
-            return None;
-        };
-        let Some(expression_context) = ctx.expression() else {
-            return None;
-        };
+        let variable_context = ctx.variable()?;
+        let expression_context = ctx.expression()?;
         let variable_type = self.visit(variable_context.as_ref());
         if let Some(variable_type) = variable_type.as_ref() {
             // giving the expression a hint just in case it is needed to help resolve any ambiguity on the expression


### PR DESCRIPTION
new version clippy or something

fixes these warning:

```
cargo clippy --workspace --all-features --tests --examples
    Blocking waiting for file lock on build directory
    Checking yarnspinner_compiler v0.2.1 (/Users/katzen/Documents/YarnSpinner-Rust/crates/compiler)
warning: this `let...else` may be rewritten with the `?` operator
   --> crates/compiler/src/visitors/type_check_visitor.rs:440:9
    |
440 | /         let Some(variable_context) = ctx.variable() else {
441 | |             return None;
442 | |         };
    | |__________^ help: replace it with: `let variable_context = ctx.variable()?;`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
    = note: `#[warn(clippy::question_mark)]` on by default

warning: this `let...else` may be rewritten with the `?` operator
   --> crates/compiler/src/visitors/type_check_visitor.rs:443:9
    |
443 | /         let Some(expression_context) = ctx.expression() else {
444 | |             return None;
445 | |         };
    | |__________^ help: replace it with: `let expression_context = ctx.expression()?;`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark

warning: `yarnspinner_compiler` (lib test) generated 2 warnings (2 duplicates)
warning: `yarnspinner_compiler` (lib) generated 2 warnings
    Checking yarnspinner v0.2.0 (/Users/katzen/Documents/YarnSpinner-Rust/crates/yarnspinner)
    Checking bevy_yarnspinner v0.2.0 (/Users/katzen/Documents/YarnSpinner-Rust/crates/bevy_plugin)
```