### PR TITLE
Make dialogue clone

### DIFF
--- a/crates/bevy_plugin/src/line_provider/text_provider/shared_text_provider.rs
+++ b/crates/bevy_plugin/src/line_provider/text_provider/shared_text_provider.rs
@@ -46,6 +46,10 @@ impl TextProvider for SharedTextProvider {
 }
 
 impl UnderlyingTextProvider for SharedTextProvider {
+    fn clone_shallow(&self) -> Box<dyn UnderlyingTextProvider> {
+        Box::new(self.clone())
+    }
+
     fn accept_line_hints(&mut self, line_ids: &[LineId]) {
         self.0.write().unwrap().accept_line_hints(line_ids)
     }

--- a/crates/bevy_plugin/src/line_provider/text_provider/strings_file_text_provider.rs
+++ b/crates/bevy_plugin/src/line_provider/text_provider/strings_file_text_provider.rs
@@ -41,6 +41,10 @@ impl Debug for StringsFileTextProvider {
 }
 
 impl UnderlyingTextProvider for StringsFileTextProvider {
+    fn clone_shallow(&self) -> Box<dyn UnderlyingTextProvider> {
+        Box::new(self.clone())
+    }
+
     fn accept_line_hints(&mut self, _line_ids: &[LineId]) {
         // no-op
     }

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -11,7 +11,7 @@ use yarnspinner_core::prelude::*;
 /// Co-ordinates the execution of Yarn programs.
 ///
 /// The main functions of interest are [`Dialogue::continue_`] and [`Dialogue::set_selected_option`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Dialogue {
     vm: VirtualMachine,
     language_code: Option<Language>,

--- a/crates/runtime/src/text_provider.rs
+++ b/crates/runtime/src/text_provider.rs
@@ -14,7 +14,7 @@ use yarnspinner_core::prelude::*;
 /// By injecting this, we don't need to expose `Dialogue.ExpandSubstitutions` and `Dialogue.ParseMarkup`, since we can apply them internally.
 pub trait TextProvider: Debug + Send + Sync {
     /// Creates a shallow clone of this text provider, i.e. a clone that
-    /// shares the same underlying storage and will thus be perfectly in sync
+    /// shares the same underlying provider and will thus be perfectly in sync
     /// with the original instance.
     fn clone_shallow(&self) -> Box<dyn TextProvider>;
     /// Passes the [`LineId`]s that this [`TextProvider`] should soon provide text for. These are the [`LineId`]s that are contained in the current node and are not required to be actually reached.

--- a/crates/runtime/src/text_provider.rs
+++ b/crates/runtime/src/text_provider.rs
@@ -13,6 +13,10 @@ use yarnspinner_core::prelude::*;
 ///
 /// By injecting this, we don't need to expose `Dialogue.ExpandSubstitutions` and `Dialogue.ParseMarkup`, since we can apply them internally.
 pub trait TextProvider: Debug + Send + Sync {
+    /// Creates a shallow clone of this text provider, i.e. a clone that
+    /// shares the same underlying storage and will thus be perfectly in sync
+    /// with the original instance.
+    fn clone_shallow(&self) -> Box<dyn TextProvider>;
     /// Passes the [`LineId`]s that this [`TextProvider`] should soon provide text for. These are the [`LineId`]s that are contained in the current node and are not required to be actually reached.
     fn accept_line_hints(&mut self, line_ids: &[LineId]);
     /// Returns the text for the given [`LineId`]. Will only be called if [`TextProvider::are_lines_available`] returns `true`.
@@ -29,6 +33,12 @@ pub trait TextProvider: Debug + Send + Sync {
     /// Gets the [`TextProvider`] as a mutable trait object.
     /// This allows retrieving the concrete type by downcasting, using the `downcast_mut` method available through the `Any` trait.
     fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl Clone for Box<dyn TextProvider> {
+    fn clone(&self) -> Self {
+        self.clone_shallow()
+    }
 }
 
 #[allow(missing_docs)]
@@ -73,6 +83,10 @@ impl StringTableTextProvider {
 }
 
 impl TextProvider for StringTableTextProvider {
+    fn clone_shallow(&self) -> Box<dyn TextProvider> {
+        Box::new(self.clone())
+    }
+
     fn accept_line_hints(&mut self, _line_ids: &[LineId]) {
         // no-op
     }

--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -15,7 +15,7 @@ use yarnspinner_core::prelude::*;
 mod execution_state;
 mod state;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct VirtualMachine {
     pub(crate) library: Library,
     pub(crate) program: Option<Program>,

--- a/crates/yarnspinner/tests/test_base/text_provider.rs
+++ b/crates/yarnspinner/tests/test_base/text_provider.rs
@@ -22,6 +22,10 @@ impl SharedTextProvider {
 }
 
 impl TextProvider for SharedTextProvider {
+    fn clone_shallow(&self) -> Box<dyn TextProvider> {
+        Box::new(self.clone())
+    }
+
     fn accept_line_hints(&mut self, line_ids: &[LineId]) {
         self.0.write().unwrap().accept_line_hints(line_ids);
     }


### PR DESCRIPTION
Hi !

So a use case I've had is to get all the paths of a yarn program.

Mostly so I can read through them individually as if they're complete stories and fix any pacing issues or weirdness.

For that, I had in mind a [recursive script thing](https://gist.github.com/stargazing-dino/e46e09ef721547668f5782c2e294cb8d) in mind that would give me all the possible paths.

Problem is that it relies on cloning a dialogue.

The primary change is making TextProvider clone but it kinda fits in line with the current way we make variable storage clone