### PR TITLE
Strip the BOM from the source string if it is present

### DIFF
--- a/crates/compiler/src/compiler/run_compilation.rs
+++ b/crates/compiler/src/compiler/run_compilation.rs
@@ -32,7 +32,7 @@ pub(crate) fn compile(compiler: &Compiler) -> Result<Compilation> {
             // Strip the BOM from the source string if it is present before compiling.
             // Rust does not do this by default
             // https://github.com/rust-lang/rfcs/issues/2428
-            let source = match file.source.strip_prefix("\u{feff}") {
+            let source = match file.source.strip_prefix('\u{feff}') {
                 None => file.source.as_str(),
                 Some(sanitized_string) => sanitized_string,
             };

--- a/crates/compiler/src/compiler/run_compilation.rs
+++ b/crates/compiler/src/compiler/run_compilation.rs
@@ -34,7 +34,7 @@ pub(crate) fn compile(compiler: &Compiler) -> Result<Compilation> {
             // https://github.com/rust-lang/rfcs/issues/2428
             let source = match file.source.strip_prefix("\u{feff}") {
                 None => file.source.as_str(),
-                Some(sanitized_string) => sanitized_string
+                Some(sanitized_string) => sanitized_string,
             };
             source.chars().map(|c| c as u32).collect()
         })

--- a/crates/compiler/src/compiler/run_compilation.rs
+++ b/crates/compiler/src/compiler/run_compilation.rs
@@ -28,7 +28,16 @@ pub(crate) fn compile(compiler: &Compiler) -> Result<Compilation> {
     let chars: Vec<Vec<u32>> = compiler
         .files
         .iter()
-        .map(|file| file.source.chars().map(|c| c as u32).collect())
+        .map(|file| {
+            // Strip the BOM from the source string if it is present before compiling.
+            // Rust does not do this by default
+            // https://github.com/rust-lang/rfcs/issues/2428
+            let source = match file.source.strip_prefix("\u{feff}") {
+                None => file.source.as_str(),
+                Some(sanitized_string) => sanitized_string
+            };
+            source.chars().map(|c| c as u32).collect()
+        })
         .collect();
     let chars: Vec<_> = chars.iter().map(|c| c.as_slice()).collect();
     let initial = CompilationIntermediate::from_job(compiler, chars);


### PR DESCRIPTION
While the Yarn Docs say they only accept UTF-8 the examples in the C# repos have yarn files using a UTF-8 with BOM encoding. This does not mess with them as C# will strip the BOM when reading the file as text. Rust though does not do this by default, instead reading it in as a character which causes compilation failures or sometimes panics to occur.

https://github.com/rust-lang/rfcs/issues/2428

This change adds a quick sanitation step when processing the files to strip the BOM from the file if it is present to line the expected behavior up with the core Yarn Spinner lib.