### PR TITLE
Track KnownTypes per file

### DIFF
--- a/crates/compiler/src/compilation_steps/check_types.rs
+++ b/crates/compiler/src/compilation_steps/check_types.rs
@@ -3,7 +3,7 @@ use crate::visitors::TypeCheckVisitor;
 use antlr_rust::tree::ParseTreeVisitorCompat;
 
 pub(crate) fn check_types(mut state: CompilationIntermediate) -> CompilationIntermediate {
-    for file in &state.parsed_files {
+    for (file, known_types) in &mut state.parsed_files {
         let mut visitor =
             TypeCheckVisitor::new(state.known_variable_declarations.clone(), file.clone());
         visitor.visit(file.tree.as_ref());
@@ -15,7 +15,7 @@ pub(crate) fn check_types(mut state: CompilationIntermediate) -> CompilationInte
             .extend(visitor.new_declarations);
         state.diagnostics.extend(visitor.diagnostics);
         state.potential_issues.extend(visitor.deferred_types);
-        state.known_types.extend(visitor.known_types);
+        known_types.extend(visitor.known_types);
     }
     state
 }

--- a/crates/compiler/src/compilation_steps/find_tracking_nodes.rs
+++ b/crates/compiler/src/compilation_steps/find_tracking_nodes.rs
@@ -9,7 +9,7 @@ pub(crate) fn find_tracking_nodes(mut state: CompilationIntermediate) -> Compila
     // so that any tracking variables are included in the compiled declarations
     let mut tracking_nodes = HashSet::new();
     let mut ignore_nodes = HashSet::new();
-    for file in &state.parsed_files {
+    for (file, _) in &state.parsed_files {
         let mut visitor = NodeTrackingVisitor::new();
         visitor.visit(file.tree.as_ref());
         tracking_nodes.extend(visitor.tracking_nodes);

--- a/crates/compiler/src/compilation_steps/generate_code.rs
+++ b/crates/compiler/src/compilation_steps/generate_code.rs
@@ -21,10 +21,10 @@ pub(crate) fn generate_code(mut state: CompilationIntermediate) -> CompilationIn
         state
             .parsed_files
             .iter()
-            .map(|file| {
+            .map(|(file, known_types)| {
                 generate_code_for_file(
                     &mut state.tracking_nodes,
-                    state.known_types.clone(),
+                    known_types.clone(),
                     template.clone(),
                     file,
                 )

--- a/crates/compiler/src/compilation_steps/get_declarations.rs
+++ b/crates/compiler/src/compilation_steps/get_declarations.rs
@@ -4,7 +4,7 @@ use antlr_rust::tree::ParseTreeVisitorCompat;
 
 pub(crate) fn get_declarations(mut state: CompilationIntermediate) -> CompilationIntermediate {
     // Find the variable declarations in these files.
-    for file in &state.parsed_files {
+    for (file, _) in &state.parsed_files {
         let mut variable_declaration_visitor =
             DeclarationVisitor::new(state.known_variable_declarations.clone(), file.clone());
 

--- a/crates/compiler/src/compilation_steps/parse_files.rs
+++ b/crates/compiler/src/compilation_steps/parse_files.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 pub(crate) fn parse_files(mut state: CompilationIntermediate) -> CompilationIntermediate {
     for (file, chars) in state.job.files.iter().zip(state.file_chars.iter()) {
         let parse_result = parse_syntax_tree(file, chars, &mut state.diagnostics);
-        state.parsed_files.push(parse_result);
+        state.parsed_files.push((parse_result, Default::default()));
     }
     state
 }

--- a/crates/compiler/src/compilation_steps/register_strings.rs
+++ b/crates/compiler/src/compilation_steps/register_strings.rs
@@ -5,7 +5,7 @@ use antlr_rust::tree::ParseTreeVisitorCompat;
 pub(crate) fn register_strings(mut state: CompilationIntermediate) -> CompilationIntermediate {
     // First pass: parse all files, generate their syntax trees,
     // and figure out what variables they've declared
-    for file in &state.parsed_files {
+    for (file, _) in &state.parsed_files {
         // ok now we will add in our lastline tags
         // we do this BEFORE we build our strings table otherwise the tags will get missed
         // this should probably be a flag instead of every time though

--- a/crates/compiler/src/compilation_steps/validate_unique_node_names.rs
+++ b/crates/compiler/src/compilation_steps/validate_unique_node_names.rs
@@ -9,7 +9,7 @@ pub(crate) fn validate_unique_node_names(
     // Ensure that all nodes names in this compilation are unique. Node
     // name uniqueness is important for several processes, so we do this
     // check here.
-    let all_nodes = state.parsed_files.iter().flat_map(|file| {
+    let all_nodes = state.parsed_files.iter().flat_map(|(file, _)| {
         file.tree
             .node_all()
             .iter()

--- a/crates/compiler/src/compiler/run_compilation.rs
+++ b/crates/compiler/src/compiler/run_compilation.rs
@@ -66,12 +66,11 @@ pub(crate) struct CompilationIntermediate<'input> {
     /// All variable declarations that we've encountered during this compilation job
     pub(crate) derived_variable_declarations: Vec<Declaration>,
     pub(crate) potential_issues: Vec<DeferredTypeDiagnostic>,
-    pub(crate) parsed_files: Vec<FileParseResult<'input>>,
+    pub(crate) parsed_files: Vec<(FileParseResult<'input>, KnownTypes)>,
     pub(crate) tracking_nodes: HashSet<String>,
     pub(crate) string_table: StringTableManager,
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(crate) file_tags: HashMap<String, Vec<String>>,
-    pub(crate) known_types: KnownTypes,
     pub(crate) early_break: bool,
 }
 
@@ -89,7 +88,6 @@ impl<'input> CompilationIntermediate<'input> {
             string_table: Default::default(),
             diagnostics: Default::default(),
             file_tags: Default::default(),
-            known_types: Default::default(),
             early_break: Default::default(),
         }
     }


### PR DESCRIPTION
Having one global `KnownTypes` is prone to collision errors, triggering a very hard to debug panic in 
[CodeGenerationVisitor::generate_code_for_operation](https://github.com/YarnSpinnerTool/YarnSpinner-Rust/blob/main/crates/compiler/src/visitors/code_generation_visitor.rs#L618]).

By tracking `KnownTypes` on a per-file basis, those panics no longer occur. 