### PR TITLE
Export `Optionality` markers

### DIFF
--- a/crates/core/src/yarn_fn.rs
+++ b/crates/core/src/yarn_fn.rs
@@ -4,7 +4,7 @@
 
 mod function_registry;
 mod function_wrapping;
-mod optionality;
+pub mod optionality;
 mod parameter_wrapping;
 
 pub(crate) use function_registry::*;

--- a/crates/core/src/yarn_fn/optionality.rs
+++ b/crates/core/src/yarn_fn/optionality.rs
@@ -5,17 +5,19 @@
 use yarnspinner_macros::all_tuples;
 
 /// Marker trait for valid optionality hints.
-pub trait Optionality {}
+pub trait Optionality: private::Sealed {}
 
 /// An optional parameter or a tuple where
 /// the last element is optional.
 pub struct Optional;
 
+impl private::Sealed for Optional {}
 impl Optionality for Optional {}
 
 /// A parameter that is required.
 pub struct Required;
 
+impl private::Sealed for Required {}
 impl Optionality for Required {}
 
 mod private {

--- a/crates/yarnspinner/src/lib.rs
+++ b/crates/yarnspinner/src/lib.rs
@@ -28,10 +28,10 @@ pub mod prelude {
 pub mod core {
     //! Core types and traits that are used by both the compiler and runtime.
     pub use yarnspinner_core::prelude::{
-        yarn_fn_type, yarn_library, Header, Instruction, IntoYarnValueFromNonYarnValue,
-        InvalidOpCodeError, Library, LineId, Node, Position, Program, Type, UntypedYarnFn, YarnFn,
-        YarnFnParam, YarnFnParamItem, YarnValue, YarnValueCastError, YarnValueWrapper,
-        YarnValueWrapperIter,
+        optionality, yarn_fn_type, yarn_library, Header, Instruction,
+        IntoYarnValueFromNonYarnValue, InvalidOpCodeError, Library, LineId, Node, Position,
+        Program, Type, UntypedYarnFn, YarnFn, YarnFnParam, YarnFnParamItem, YarnValue,
+        YarnValueCastError, YarnValueWrapper, YarnValueWrapperIter,
     };
 }
 pub mod compiler {


### PR DESCRIPTION
In order to support custom implementations of `YarnFnParam`, `Optional` and `Required` need to be exported.

This exports `yarnspinner_core::yarn_fn::optionality` as `yarnspinner_core::prelude::optionality` and seals the `AllowedOptionalityChain` trait so it cannot be implemented.