### PR TITLE
Invert text_for_attribute length assertion comparison

### DIFF
--- a/crates/runtime/src/line.rs
+++ b/crates/runtime/src/line.rs
@@ -148,7 +148,7 @@ impl Line {
     /// Returns the substring of [`Line::text`] covered by the passed `attribute`s [`MarkupAttribute::position`] and [`MarkupAttribute::length`] fields.
     pub fn text_for_attribute(&self, attribute: &MarkupAttribute) -> &str {
         assert!(
-            self.text.len() <= attribute.position + attribute.length,
+            self.text.len() >= attribute.position + attribute.length,
             "Attribute \"{attribute}\" represents a range not representable by this text: \"{}\". \
         Does this MarkupAttribute belong to this MarkupParseResult?",
             self.text


### PR DESCRIPTION
I was trying to work with markup attributes in my project and would encounter a panic when executing the `Line::text_for_attribute` function, as it would consistently fail the following assertion:

```rs
assert!(
    self.text.len() <= attribute.position + attribute.length,
    "Attribute \"{attribute}\" represents a range not representable by this text: \"{}\". \
Does this MarkupAttribute belong to this MarkupParseResult?",
    self.text
);
```

This assertion seems to be checking that the text length is *shorter* than the attribute's range. This pull request just flips the comparison from `<=` to `>=`.