### PR TITLE
Show options when they are created after the typewriter finishes

### DIFF
--- a/crates/example_dialogue_view/src/option_selection.rs
+++ b/crates/example_dialogue_view/src/option_selection.rs
@@ -51,10 +51,13 @@ fn create_options(
     children: Query<&Children>,
     options_node: Single<(Entity, &mut Node, &mut Visibility), With<OptionsNode>>,
     mut root_visibility: Single<&mut Visibility, (With<UiRootNode>, Without<OptionsNode>)>,
+    typewriter: Res<Typewriter>,
 ) {
     let (entity, mut node, mut visibility) = options_node.into_inner();
     node.display = Display::Flex;
-    *visibility = Visibility::Hidden;
+    if !typewriter.is_finished() {
+        *visibility = Visibility::Hidden;
+    }
     if children.iter_descendants(entity).next().is_none() {
         **root_visibility = Visibility::Inherited;
         let mut entity_commands = commands.entity(entity);


### PR DESCRIPTION
This fixes #225 for me. I think this approach makes sense and it seems to work in the tests and examples I've run but I'll admit I don't have the whole logic of the dialogue view in my head so it could be this causes problems somewhere else.