### PR TITLE
Unify functions and commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,21 @@
 name: CI
 
 on:
-  pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
-  # Sparse cargo registry for faster updates
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUSTFLAGS: --deny warnings
+  RUSTDOCFLAGS: --deny warnings
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
-    env:
-      # Handle cargo check and cargo clippy warnings as errors
-      RUSTFLAGS: "-D warnings"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,23 +24,22 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Populate target directory from cache
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo clippy
-        run: cargo clippy --workspace --all-features --tests --examples --exclude yarnspinner_without_bevy_examples
-      - name: Run cargo clippy for serde
-        run: cargo clippy --workspace --tests --features serde --exclude yarnspinner_without_bevy_examples
-      - name: Run cargo clippy for bevy
-        run: cargo clippy --workspace --tests --features bevy --exclude yarnspinner_without_bevy_examples
+        run: cargo clippy --workspace --all-features --tests --examples --exclude yarnspinner_without_bevy_examples -- --deny warnings
       - name: Run cargo clippy for non-bevy
-        run: cargo clippy --tests
-        working-directory: examples/yarnspinner_without_bevy
+        run: cargo clippy --no-default-features --tests -p yarnspinner -p yarnspinner_without_bevy_examples -- --deny warnings
 
 
   format:
+    name: Format
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-D warnings"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,13 +49,12 @@ jobs:
           toolchain: stable
           components: rustfmt
       - name: Run cargo fmt
-        run: cargo fmt --check --all
+        run: cargo fmt --all -- --check
 
   doc:
+    name: Docs
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-D warnings"
-      RUSTDOCFLAGS: '--deny warnings'
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,13 +62,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+      - name: Populate target directory from cache
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo doc
-        run: cargo doc --no-deps --workspace --all-features
+        run: cargo doc --no-deps --workspace --all-features --exclude yarnspinner_without_bevy_examples
+      - name: Run cargo doc for non-bevy
+        run: cargo doc --no-default-features --no-deps -p yarnspinner -p yarnspinner_without_bevy_examples
 
-  test:
+  test-bevy:
+    name: Test with Bevy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -78,18 +84,35 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+      - name: Populate target directory from cache
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo test
-        run: cargo test
-        working-directory: crates/yarnspinner
-      - name: Run cargo test non-bevy
-        run: cargo test
-        working-directory: examples/yarnspinner_without_bevy
-      - name: Run cargo test
         run: cargo test --workspace --all-features --exclude yarnspinner_without_bevy_examples
       - name: Run doc tests
-        run: cargo test --workspace --doc --exclude yarnspinner_without_bevy_examples
-      - name: Run doc tests non-bevy
-        run: cargo test --doc
-        working-directory: examples/yarnspinner_without_bevy
+        run: LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --workspace --all-features --doc --exclude yarnspinner_without_bevy_examples
+
+  test-without-bevy:
+    name: Test without Bevy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Populate target directory from cache
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Run cargo test for non-bevy
+        run: cargo test --no-default-features -p yarnspinner -p yarnspinner_without_bevy_examples
+      - name: Run doc tests for non-bevy
+        run: LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --doc --no-default-features -p yarnspinner -p yarnspinner_without_bevy_examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -349,18 +349,18 @@ checksum = "1795ebc740ea791ffbe6685e0688ab1effec16c2864e0476db40bfdf0c02cb3d"
 
 [[package]]
 name = "bevy"
-version = "0.16.0-rc.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66ee4b3dee30684ad59146b06a09952da817fb6a22ad25ee8c6f1dc5ab15cf5"
+checksum = "2a5cd3b24a5adb7c7378da7b3eea47639877643d11b6b087fc8a8094f2528615"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afaf5487efe467b3169b0f944940efef0136d41e3b293b3afb45cc5f4e421b4"
+checksum = "91ed969a58fbe449ef35ebec58ab19578302537f34ee8a35d04e5a038b3c40f5"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ed7f10e5a04392c7a85612d32a682c966bfd20ec7cd10c9e301e8fb8284397"
+checksum = "3647b67c6bfd456922b2720ccef980dec01742d155d0eb454dc3d8fdc65e7aff"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -384,7 +384,7 @@ dependencies = [
  "bevy_log",
  "bevy_math",
  "bevy_mesh",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
@@ -406,13 +406,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cdcee5cf8cfc0e92c027e7a274d69c1a89158e3c9b50f6f5bb109f725f9152"
+checksum = "a2b6267ac23a9947d5b2725ff047a1e1add70076d85fa9fb73d044ab9bea1f3c"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c543a58c695feaa63f7f12ea0c1239105828c3303f32ae47f6a9b5fae620f15e"
+checksum = "0698040d63199391ea77fd02e039630748e3e335c3070c6d932fd96cbf80f5d6"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -440,7 +440,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70896cb740ad13a746e2ff49719ec294adb57be60eb27e314a6f672b6c104b3"
+checksum = "0bf8c00b5d532f8e5ac7b49af10602f9f7774a2d522cf0638323b5dfeee7b31c"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aa580b25b80fce33f60742127cadfe84a6b62d0d0fd6202a81617f76da8d53"
+checksum = "74e54154e6369abdbaf5098e20424d59197c9b701d4f79fe8d0d2bde03d25f12"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.16.0-rc.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8ccf4d7368e176df8f90a4d0c2169bd7561d2982b1a3d08ec9e78b05d0032f"
+checksum = "ddf6a5ad35496bbc41713efbcf06ab72b9a310fabcab0f9db1debb56e8488c6e"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0967347cb52a5cdf03ce19a20b2afc11bbdbd1a3d5675b802b76a35964dce2f7"
+checksum = "55c2310717b9794e4a45513ee5946a7be0838852a4c1e185884195e1a8688ff3"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -528,7 +528,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d5f78757eff8d91e37d14955108ce261d11d862b618acd0b0af940a226f7d7"
+checksum = "f626531b9c05c25a758ede228727bd11c2c2c8498ecbed9925044386d525a2a3"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -557,13 +557,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78972c5da2e8d1a562499daceffa50b8445e5a909b5aa8ace743cb7f082084ac"
+checksum = "048a1ff3944a534b8472516866284181eef0a75b6dd4d39b6e5925715e350766"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_tasks",
  "bevy_time",
  "bevy_utils",
@@ -575,13 +575,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cae38412de6e3f878f393e70d10fa7c1b00822f381ea34892eed57c68dc3b6a"
+checksum = "d9e807b5d9aab3bb8dfe47e7a44c9ff088bad2ceefe299b80ac77609a87fe9d4"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_tasks",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196a5034c0175a64d4daba51f8222a9c1e8d48e6b41dd66cc56e5dfe67a5aa0d"
+checksum = "467d7bb98aeb8dd30f36e6a773000c12a891d4f1bee2adc3841ec89cc8eaf54e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a0b084f47812eb4ab635675709f5cfe6ffa0b122ba56bfaebdd13d46e23af8"
+checksum = "b8bb31dc1090c6f8fabbf6b21994d19a12766e786885ee48ffc547f0f1fa7863"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -625,14 +625,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3e2ce153a9f8bc659d4e239372fbc7c153cafc12589c10bcd97140ab2e3060"
+checksum = "950c84596dbff8a9691a050c37bb610ef9398af56369c2c2dd6dc41ef7b717a5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_time",
  "bevy_utils",
  "gilrs",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4b252378a0217824ea9f8981df6fd8c4e78590d64ce01e068954ca5fe7133"
+checksum = "54af8145b35ab2a830a6dd1058e23c1e1ddc4b893db79d295259ef82f51c7520"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d4b5465e40de18c6d0b9b8f03db60f1a748052138697eb81383a1f6901ccef"
+checksum = "40137ace61f092b7a09eba41d7d1e6aef941f53a7818b06ef86dcce7b6a1fd3f"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192f70193ca069df06fcfd7ed1cb61c09e571275303e6ec517d76ff4c20210f5"
+checksum = "aa25b809ee024ef2682bafc1ca22ca8275552edb549dc6f69a030fdffd976c63"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -691,11 +691,10 @@ dependencies = [
  "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_image",
- "bevy_log",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
@@ -715,15 +714,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749aeaed9e736750eba3ef3b54556ab49e405eb18f190a82fcf3c4b853b03e2e"
+checksum = "840b25f7f58894c641739f756959028a04f519c448db7e2cd3e2e29fc5fd188d"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
  "bitflags 2.9.0",
@@ -743,14 +742,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547d4a5e175fc2bd26e0115ae37256544b8edf0892864b791031698c2d6af8ee"
+checksum = "763410715714f3d4d2dcdf077af276e2e4ea93fd8081b183d446d060ea95baaa"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
  "derive_more",
@@ -762,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79561d77e9d99a95039a601d2ffd86db1da7d5d0b25453fb32c8df4a5168eef4"
+checksum = "d7e7b4ed65e10927a39a987cf85ef98727dd319aafb6e6835f2cb05b883c6d66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -778,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.16.0-rc.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd5e43ab39f5e93732003e805bd37f2b89f92432eb350655cd3bc56849514af"
+checksum = "526ffd64c58004cb97308826e896c07d0e23dc056c243b97492e31cdf72e2830"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -802,7 +801,7 @@ dependencies = [
  "bevy_math",
  "bevy_pbr",
  "bevy_picking",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_render",
@@ -821,15 +820,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b9aac9641a105556f1d28860aaed29513031849e324e0b75cd5d8aeacbee48"
+checksum = "7156df8d2f11135cf71c03eb4c11132b65201fd4f51648571e59e39c9c9ee2f6"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
  "bevy_utils",
- "log",
  "tracing",
  "tracing-log",
  "tracing-oslog",
@@ -839,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e910801472bfd99ecf22723c27227bd78382857425afee0ce296749cbb809c"
+checksum = "7a2473db70d8785b5c75d6dd951a2e51e9be2c2311122db9692c79c9d887517b"
 dependencies = [
  "parking_lot 0.12.3",
  "proc-macro2",
@@ -852,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d395017ec71d17d2ffa05d8586a357c2d7e61b94ba8585c42990e199340070"
+checksum = "f1a3a926d02dc501c6156a047510bdb538dcb1fa744eeba13c824b73ba88de55"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -872,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc23f376bfaf0792292f93f028f8ac7bd573af062733cec8ec14cb278f299604"
+checksum = "12af58280c7453e32e2f083d86eaa4c9b9d03ea8683977108ded8f1930c539f2"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -882,7 +880,7 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_mikktspace",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
@@ -897,18 +895,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4e9675786e709d53b7b3e39ddffdf46b5f71024f8b97ec9af63d5b64d9bbfa"
+checksum = "75e0258423c689f764556e36b5d9eebdbf624b29a1fd5b33cd9f6c42dcc4d5f3"
 dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7b50fefef13c4ccf7d34237055dad6284c46608f59eceadba17a22d2f19b28"
+checksum = "d9fe0de43b68bf9e5090a33efc963f125e9d3f9d97be9ebece7bcfdde1b6da80"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -919,7 +917,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
@@ -940,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_picking"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83844abfbd567b10bdb7f15a9419b0936b989cb888dbd9fc022dcfe60c8e2d48"
+checksum = "f73674f62b1033006bd75c89033f5d3516386cfd7d43bb9f7665012c0ab14d22"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -951,7 +949,7 @@ dependencies = [
  "bevy_input",
  "bevy_math",
  "bevy_mesh",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
@@ -964,15 +962,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_platform_support"
-version = "0.16.0-rc.4"
+name = "bevy_platform"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07dae2ae4e79ae57147d7fe90362af18fbace134f66c537a45a8315f4855d53"
+checksum = "704db2c11b7bc31093df4fbbdd3769f9606a6a5287149f4b51f2680f25834ebc"
 dependencies = [
  "cfg-if",
  "critical-section",
  "foldhash",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "hashbrown",
  "portable-atomic",
  "portable-atomic-util",
@@ -983,18 +981,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b7a509abaeec48bb12bf54b2fe4ebf85ba9a23efe69de11f699f5620d59f4"
+checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5012385cdb94f09546a0e077ef4c34f951b60b8ec84da77c2f76a6346a0f9154"
+checksum = "607ebacc31029cf2f39ac330eabf1d4bc411b159528ec08dbe6b0593eaccfd41"
 dependencies = [
  "assert_type_match",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect_derive",
  "bevy_utils",
@@ -1016,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc52bd2025f1be16c1f090f5426f3c96f3528a6aa982390b6e3a5c41f79ea6b1"
+checksum = "cf35e45e4eb239018369f63f2adc2107a54c329f9276d020e01eee1625b0238b"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1029,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27b75744a303dfcec8dfa320f830e814ac6736b0acb18c2c9cadee60e480a4c"
+checksum = "85a7306235b3343b032801504f3e884b93abfb7ba58179fc555c479df509f349"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1044,7 +1042,7 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_mesh",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render_macros",
  "bevy_tasks",
@@ -1081,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9300829586bef873b33bde1e8e635504704016ae2f9c1a0d371e17c3cd3ef60"
+checksum = "b85c4fb26b66d3a257b655485d11b9b6df9d3c85026493ba8092767a5edfc1b2"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1093,15 +1091,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32de0bb0357b7865079607716f659623a15a95d84a4c92b91d8cd32c1f56200"
+checksum = "e7b628f560f2d2fe9f35ecd4526627ba3992f082de03fd745536e4053a0266fe"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
@@ -1114,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b112a50e9c68bfafc1e7de66ec8250dcf34c325afa4a7e1c420bb464adb7671c"
+checksum = "01f97bf54fb1c37a1077139b59bb32bc77f7ca53149cfcaa512adbb69a2d492c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1127,7 +1125,7 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_picking",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
@@ -1145,20 +1143,20 @@ dependencies = [
 [[package]]
 name = "bevy_sprite3d"
 version = "5.0.0-rc.1"
-source = "git+https://github.com/Caudiciform-Studios/bevy_sprite3d.git#4e77e7f763f3f3388c194e0c37bd9786cf8127bb"
+source = "git+https://github.com/extrawurst/bevy_sprite3d.git?branch=bevy-0.16#e8e03a4c079e9180f971c5dbc23dce19e76dc9df"
 dependencies = [
  "bevy",
 ]
 
 [[package]]
 name = "bevy_state"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea5f7570b0c3f6ebe0de222aeb94575fd3a345ddb677285e9485157050d1cbf"
+checksum = "682c343c354b191fe6669823bce3b0695ee1ae4ac36f582e29c436a72b67cdd5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_state_macros",
  "bevy_utils",
@@ -1168,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de272e40f641418dd784a8722e9b7491741e939374e004bf73005b50e4047eba"
+checksum = "55b4bf3970c4f0e60572901df4641656722172c222d71a80c430d36b0e31426c"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1180,15 +1178,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98675766d6cadb171699652c468f8fb0a741e0f4a94e123e95d42e6e39da850"
+checksum = "444c450b65e108855f42ecb6db0c041a56ea7d7f10cc6222f0ca95e9536a7d19"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-task",
  "atomic-waker",
- "bevy_platform_support",
+ "bevy_platform",
  "cfg-if",
  "concurrent-queue",
  "crossbeam-queue",
@@ -1202,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3925163ece7df7d3e14bf3fb16036a80e8259415f49c8920f51e84a7cd9dd78d"
+checksum = "8ef071262c5a9afbc39caba4c0b282c7d045fbb5cf33bdab1924bd2343403833"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1214,7 +1212,7 @@ dependencies = [
  "bevy_image",
  "bevy_log",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
@@ -1232,13 +1230,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a067ea7d90112141ff23e210bfbf2ad81d9b976d056a5878998b20c25b123017"
+checksum = "456369ca10f8e039aaf273332744674844827854833ee29e28f9e161702f2f55"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "crossbeam-channel",
  "log",
@@ -1247,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528f8839e88dc3263bbce3b31b4367b379fd995b862641d4a64ae8e68eab2e92"
+checksum = "8479cdd5461246943956a7c8347e4e5d6ff857e57add889fb50eee0b5c26ab48"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1265,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c153da1b126e90658fb1d5938c3642640399a7576b1ccea476ef089356ad36e1"
+checksum = "110dc5d0059f112263512be8cd7bfe0466dfb7c26b9bf4c74529355249fd23f9"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1281,7 +1279,7 @@ dependencies = [
  "bevy_input",
  "bevy_math",
  "bevy_picking",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
@@ -1301,26 +1299,26 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee384d4ed938bc91591f551f103c1f1822a60ea731dfc17362e9d149d681c13"
+checksum = "ac2da3b3c1f94dadefcbe837aaa4aa119fcea37f7bdc5307eb05b4ede1921e24"
 dependencies = [
- "bevy_platform_support",
+ "bevy_platform",
  "thread_local",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48526511ab22a044e1e8fe692e18e0f4038bc6082396cb804c452c6526b60860"
+checksum = "0d83327cc5584da463d12b7a88ddb97f9e006828832287e1564531171fffdeb4"
 dependencies = [
  "android-activity",
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
  "log",
@@ -1331,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.16.0-rc.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04429e9ad430bcc9283695564d950135fcf2c69f7a900d5d242fbe2f6d78826c"
+checksum = "57b14928923ae4274f4b867dce3d0e7b2c8a31bebcb0f6e65a4261c3e0765064"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1348,7 +1346,7 @@ dependencies = [
  "bevy_input_focus",
  "bevy_log",
  "bevy_math",
- "bevy_platform_support",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -1367,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_yarnspinner"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1394,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_yarnspinner_example_dialogue_view"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "bevy",
  "bevy_yarnspinner",
@@ -1468,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1591,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -2373,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2956,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -2972,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -3460,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -3893,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4007,7 +4005,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -4357,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -4486,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "svg_fmt"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5d813d71d82c4cbc1742135004e4a79fd870214c155443451c139c9470a0aa"
+checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
@@ -5677,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -5758,7 +5756,7 @@ checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "yarnspinner"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bevy",
@@ -5779,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "yarnspinner_compiler"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "annotate-snippets",
  "antlr-rust",
@@ -5794,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "yarnspinner_core"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "bevy",
  "prost",
@@ -5814,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "yarnspinner_runtime"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "bevy",
  "fixed_decimal",

--- a/crates/bevy_plugin/Cargo.toml
+++ b/crates/bevy_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_yarnspinner"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust"
 homepage = "https://docs.yarnspinner.dev/"
@@ -23,14 +23,14 @@ serde = { version = "1", features = ["derive"] }
 yarnspinner = { path = "../yarnspinner", features = [
     "bevy",
     "serde",
-], version = "0.5.0-rc" }
+], version = "0.5.0" }
 sha2 = "0.10"
 rand = { version = "0.8", features = ["small_rng"] }
 variadics_please = "1"
 
 
 [dependencies.bevy]
-version = "0.16.0-rc"
+version = "0.16.0"
 default-features = false
 features = ["bevy_asset", "multi_threaded", "bevy_log"]
 
@@ -39,7 +39,7 @@ tempfile = "3"
 static_assertions = "1.1.0"
 
 [dev-dependencies.bevy]
-version = "0.16.0-rc"
+version = "0.16.0"
 default-features = false
 features = ["bevy_core_pipeline", "bevy_audio"]
 

--- a/crates/bevy_plugin/assets/functions.yarn
+++ b/crates/bevy_plugin/assets/functions.yarn
@@ -1,0 +1,6 @@
+title: Start
+---
+Data = {swap_data("After Swap")}
+New Data = {swap_data("After Second Swap")}
+Picky, picky: {picky_function()}
+===

--- a/crates/bevy_plugin/src/commands/command_registry.rs
+++ b/crates/bevy_plugin/src/commands/command_registry.rs
@@ -108,17 +108,23 @@ impl YarnCommands {
     /// Constructs an instance of [`YarnCommands`] with the builtin commands `wait` and `stop`.
     /// - `stop`: Stops the execution of the dialogue.
     /// - `wait`: Waits for the given amount of seconds before continuing the dialogue. Note that this does not block and that Bevy will continue updating as normal in the meantime.
-    pub fn builtin_commands() -> Self {
+    pub fn builtin_commands(bevy_commands: &mut Commands) -> Self {
         let mut commands = Self::default();
 
-        commands.add_command("wait", |In(duration): In<f32>, mut wait: ResMut<Wait>| {
-            wait.add(Duration::from_secs_f32(duration))
-        });
+        commands.add_command(
+            "wait",
+            bevy_commands.register_system(|In(duration): In<f32>, mut wait: ResMut<Wait>| {
+                wait.add(Duration::from_secs_f32(duration))
+            }),
+        );
 
         #[allow(clippy::unused_unit)] // Needed for 2024 edition
-        commands.add_command("stop", |_: In<()>| -> () {
-            unreachable!("The stop command is a compiler builtin and is thus not callable");
-        });
+        commands.add_command(
+            "stop",
+            bevy_commands.register_system(|_: In<()>| -> () {
+                unreachable!("The stop command is a compiler builtin and is thus not callable");
+            }),
+        );
 
         commands
     }
@@ -165,22 +171,28 @@ mod tests {
     #[test]
     fn can_add_fn_with_empty_tuple_in_args() {
         let mut methods = YarnCommands::default();
-        methods.add_command("test", |_: In<()>| {});
+        let mut world = World::default();
+        methods.add_command("test", world.register_system(|_: In<()>| {}));
     }
 
     #[test]
     fn can_add_fn_with_one_in_arg() {
         let mut methods = YarnCommands::default();
-        methods.add_command("test", |_: In<f32>| {});
+        let mut world = World::default();
+        methods.add_command("test", world.register_system(|_: In<f32>| {}));
     }
 
     #[test]
     #[should_panic = "It works!"]
     fn can_call_fn_with_no_args() {
         let mut methods = YarnCommands::default();
+        let mut world = World::default();
 
         #[allow(clippy::unused_unit)] // Needed for 2024 edition
-        methods.add_command("test", |_: In<()>| -> () { panic!("It works!") });
+        methods.add_command(
+            "test",
+            world.register_system(|_: In<()>| -> () { panic!("It works!") }),
+        );
         let method = methods.get_mut("test").unwrap();
         let mut app = App::new();
         method.call(vec![], app.world_mut());
@@ -189,8 +201,12 @@ mod tests {
     #[test]
     fn can_call_fn_with_one_arg() {
         let mut methods = YarnCommands::default();
+        let mut world = World::default();
 
-        methods.add_command("test", |In(a): In<f32>| assert_eq!(1.0, a));
+        methods.add_command(
+            "test",
+            world.register_system(|In(a): In<f32>| assert_eq!(1.0, a)),
+        );
         let method = methods.get_mut("test").unwrap();
         let mut app = App::new();
         method.call(to_method_params([1.0]), app.world_mut());
@@ -199,16 +215,22 @@ mod tests {
     #[test]
     fn can_add_multiple_fns() {
         let mut methods = YarnCommands::default();
+        let mut world = World::default();
 
-        methods.add_command("test1", |_: In<()>| {});
-        methods.add_command("test2", |_: In<f32>| {});
+        methods.add_command("test1", world.register_system(|_: In<()>| {}));
+        methods.add_command("test2", world.register_system(|_: In<f32>| {}));
     }
 
     #[test]
     fn can_call_multiple_fns() {
         let mut methods = YarnCommands::default();
-        methods.add_command("test1", |_: In<()>| {});
-        methods.add_command("test2", |In(a): In<f32>| assert_eq!(1.0, a));
+        let mut world = World::default();
+
+        methods.add_command("test1", world.register_system(|_: In<()>| {}));
+        methods.add_command(
+            "test2",
+            world.register_system(|In(a): In<f32>| assert_eq!(1.0, a)),
+        );
 
         let mut app = App::new();
         {
@@ -222,9 +244,14 @@ mod tests {
     #[test]
     fn can_mutate_world() {
         let mut methods = YarnCommands::default();
-        methods.add_command("test", |In(a): In<f32>, mut commands: Commands| {
-            commands.insert_resource(Data(a))
-        });
+        let mut world = World::default();
+
+        methods.add_command(
+            "test",
+            world.register_system(|In(a): In<f32>, mut commands: Commands| {
+                commands.insert_resource(Data(a))
+            }),
+        );
 
         #[derive(Resource)]
         struct Data(f32);
@@ -244,10 +271,15 @@ mod tests {
     #[test]
     fn executes_task() {
         let mut methods = YarnCommands::default();
-        methods.add_command("test", |_: In<()>| -> Task<()> {
-            let thread_pool = AsyncComputeTaskPool::get_or_init(TaskPool::new);
-            thread_pool.spawn(async move { sleep(Duration::from_millis(500)) })
-        });
+        let mut world = World::default();
+
+        methods.add_command(
+            "test",
+            world.register_system(|_: In<()>| -> Task<()> {
+                let thread_pool = AsyncComputeTaskPool::get_or_init(TaskPool::new);
+                thread_pool.spawn(async move { sleep(Duration::from_millis(500)) })
+            }),
+        );
         let method = methods.get_mut("test").unwrap();
 
         let mut app = App::new();
@@ -261,7 +293,9 @@ mod tests {
     fn debug_prints_signature() {
         let mut methods = YarnCommands::default();
 
-        methods.add_command("test", |_: In<(f32, f32)>| {});
+        let mut world = World::default();
+
+        methods.add_command("test", world.register_system(|_: In<(f32, f32)>| {}));
         let debug_string = format!("{:?}", methods);
 
         let element_start = debug_string.find('{').unwrap();

--- a/crates/bevy_plugin/src/commands/command_registry.rs
+++ b/crates/bevy_plugin/src/commands/command_registry.rs
@@ -137,9 +137,10 @@ impl YarnCommands {
 /// # use bevy::prelude::*;
 /// # use bevy_yarnspinner::prelude::*;
 /// # use bevy_yarnspinner::yarn_commands;
+/// # let mut world = World::default();
 ///
 /// let commands = yarn_commands! {
-///    "add_player" => add_player,
+///    "add_player" => world.register_system(add_player),
 /// };
 ///
 /// fn add_player(In((name, age)): In<(String, f32)>) {
@@ -194,8 +195,7 @@ mod tests {
             world.register_system(|_: In<()>| -> () { panic!("It works!") }),
         );
         let method = methods.get_mut("test").unwrap();
-        let mut app = App::new();
-        method.call(vec![], app.world_mut());
+        method.call(vec![], &mut world);
     }
 
     #[test]
@@ -208,8 +208,7 @@ mod tests {
             world.register_system(|In(a): In<f32>| assert_eq!(1.0, a)),
         );
         let method = methods.get_mut("test").unwrap();
-        let mut app = App::new();
-        method.call(to_method_params([1.0]), app.world_mut());
+        method.call(to_method_params([1.0]), &mut world);
     }
 
     #[test]
@@ -232,13 +231,12 @@ mod tests {
             world.register_system(|In(a): In<f32>| assert_eq!(1.0, a)),
         );
 
-        let mut app = App::new();
         {
             let method1 = methods.get_mut("test1").unwrap();
-            method1.call(vec![], app.world_mut());
+            method1.call(vec![], &mut world);
         }
         let method2 = methods.get_mut("test2").unwrap();
-        method2.call(to_method_params([1.0]), app.world_mut());
+        method2.call(to_method_params([1.0]), &mut world);
     }
 
     #[test]
@@ -258,9 +256,8 @@ mod tests {
 
         let method = methods.get_mut("test").unwrap();
 
-        let mut app = App::new();
-        method.call(to_method_params([1.0]), app.world_mut());
-        let data = app.world().resource::<Data>();
+        method.call(to_method_params([1.0]), &mut world);
+        let data = world.resource::<Data>();
         assert_eq!(data.0, 1.0);
     }
 
@@ -282,8 +279,7 @@ mod tests {
         );
         let method = methods.get_mut("test").unwrap();
 
-        let mut app = App::new();
-        let task = method.call(vec![], app.world_mut());
+        let task = method.call(vec![], &mut world);
         assert!(!task.is_finished());
         sleep(Duration::from_millis(600));
         assert!(task.is_finished());
@@ -305,9 +301,6 @@ mod tests {
         let element = &debug_string[element_start..element_end];
 
         // Not testing the part after because its stability is not guaranteed.
-        assert_eq!(
-            element,
-            "{\"test\": fn(bevy_ecs::system::input::In<(f32, f32)>)"
-        );
+        assert_eq!(element, "{\"test\": ((f32, f32), ())");
     }
 }

--- a/crates/bevy_plugin/src/commands/command_registry/wait.rs
+++ b/crates/bevy_plugin/src/commands/command_registry/wait.rs
@@ -2,7 +2,7 @@
 //! Alas, Wasm forces us to do this
 
 use crate::prelude::YarnSpinnerSystemSet;
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/crates/bevy_plugin/src/commands/command_wrapping.rs
+++ b/crates/bevy_plugin/src/commands/command_wrapping.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use variadics_please::all_tuples;
-use yarnspinner::core::{YarnFnParam, YarnFnParamItem, YarnValueWrapper};
+use yarnspinner::core::{YarnFnParam, YarnValueWrapper};
 
 pub(crate) fn command_wrapping_plugin(_app: &mut App) {}
 

--- a/crates/bevy_plugin/src/commands/command_wrapping.rs
+++ b/crates/bevy_plugin/src/commands/command_wrapping.rs
@@ -314,15 +314,19 @@ pub mod tests {
     }
 
     macro_rules! assert_is_yarn_command {
+        (($param:ty) -> $ret:ty) => {
+            static_assertions::assert_impl_all!(SystemId<In<$param>, $ret>: YarnCommand<($param, $ret)>);
+        };
         (($($param:ty),*) -> $ret:ty) => {
-            #[allow(unused_parens)]
             static_assertions::assert_impl_all!(SystemId<In<($($param),*)>, $ret>: YarnCommand<(($($param),*), $ret)>);
         };
     }
 
     macro_rules! assert_is_not_yarn_command {
+        (($param:ty) -> $ret:ty) => {
+            static_assertions::assert_not_impl_all!(SystemId<In<$param>, $ret>: YarnCommand<($param, $ret)>);
+        };
         (($($param:ty),*) -> $ret:ty) => {
-            #[allow(unused_parens)]
             static_assertions::assert_not_impl_all!(SystemId<In<($($param),*)>, $ret>: YarnCommand<(($($param),*), $ret)>);
         };
     }

--- a/crates/bevy_plugin/src/commands/command_wrapping.rs
+++ b/crates/bevy_plugin/src/commands/command_wrapping.rs
@@ -315,12 +315,14 @@ pub mod tests {
 
     macro_rules! assert_is_yarn_command {
         (($($param:ty),*) -> $ret:ty) => {
+            #[allow(unused_parens)]
             static_assertions::assert_impl_all!(SystemId<In<($($param),*)>, $ret>: YarnCommand<(($($param),*), $ret)>);
         };
     }
 
     macro_rules! assert_is_not_yarn_command {
         (($($param:ty),*) -> $ret:ty) => {
+            #[allow(unused_parens)]
             static_assertions::assert_not_impl_all!(SystemId<In<($($param),*)>, $ret>: YarnCommand<(($($param),*), $ret)>);
         };
     }

--- a/crates/bevy_plugin/src/dialogue_runner.rs
+++ b/crates/bevy_plugin/src/dialogue_runner.rs
@@ -14,8 +14,10 @@ use crate::prelude::*;
 use crate::UnderlyingYarnLine;
 use anyhow::{anyhow, bail, Result};
 use bevy::asset::LoadedUntypedAsset;
-use bevy::platform_support::collections::HashSet;
-use bevy::{platform_support::collections::HashMap, prelude::*};
+use bevy::{
+    platform::collections::{HashMap, HashSet},
+    prelude::*,
+};
 pub(crate) use runtime_interaction::DialogueExecutionSystemSet;
 use std::any::TypeId;
 use std::fmt::Debug;

--- a/crates/bevy_plugin/src/dialogue_runner/builder.rs
+++ b/crates/bevy_plugin/src/dialogue_runner/builder.rs
@@ -25,7 +25,7 @@ pub struct DialogueRunnerBuilder {
 
 impl DialogueRunnerBuilder {
     #[must_use]
-    pub(crate) fn from_yarn_project(yarn_project: &YarnProject) -> Self {
+    pub(crate) fn from_yarn_project(yarn_project: &YarnProject, commands: &mut Commands) -> Self {
         Self {
             variable_storage: Box::new(MemoryVariableStorage::new()),
             text_provider: SharedTextProvider::new(StringsFileTextProvider::from_yarn_project(
@@ -33,7 +33,7 @@ impl DialogueRunnerBuilder {
             )),
             asset_providers: HashMap::default(),
             library: create_extended_standard_library(),
-            commands: YarnCommands::builtin_commands(),
+            commands: YarnCommands::builtin_commands(commands),
             compilation: yarn_project.compilation().clone(),
             localizations: yarn_project.localizations().cloned(),
             asset_server: yarn_project.asset_server.clone(),

--- a/crates/bevy_plugin/src/dialogue_runner/builder.rs
+++ b/crates/bevy_plugin/src/dialogue_runner/builder.rs
@@ -2,7 +2,7 @@ use crate::default_impl::{MemoryVariableStorage, StringsFileTextProvider};
 use crate::fmt_utils::SkipDebug;
 use crate::line_provider::SharedTextProvider;
 use crate::prelude::*;
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::any::{Any, TypeId};

--- a/crates/bevy_plugin/src/dialogue_runner/runtime_interaction.rs
+++ b/crates/bevy_plugin/src/dialogue_runner/runtime_interaction.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 use anyhow::bail;
 use bevy::asset::LoadedUntypedAsset;
 use bevy::ecs::system::SystemState;
-use bevy::platform_support::{collections::HashMap, hash::FixedHasher};
+use bevy::platform::{collections::HashMap, hash::FixedHasher};
 use bevy::prelude::*;
 
 pub(crate) fn runtime_interaction_plugin(app: &mut App) {

--- a/crates/bevy_plugin/src/lib.rs
+++ b/crates/bevy_plugin/src/lib.rs
@@ -83,7 +83,7 @@
 //! }
 //!
 //! fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
-//!     let mut dialogue_runner = project.create_dialogue_runner();
+//!     let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
 //!     // Start the dialog at the node with the title "Start"
 //!     dialogue_runner.start_node("Start");
 //!     commands.spawn(dialogue_runner);

--- a/crates/bevy_plugin/src/line_provider/asset_provider.rs
+++ b/crates/bevy_plugin/src/line_provider/asset_provider.rs
@@ -3,7 +3,7 @@ use crate::UnderlyingYarnLine;
 #[cfg(feature = "audio_assets")]
 pub use audio_asset_provider_plugin::AudioAssetProvider;
 use bevy::asset::{Asset, LoadedUntypedAsset};
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 pub use file_extension_asset_provider_plugin::{file_extensions, FileExtensionAssetProvider};
 use std::any::Any;

--- a/crates/bevy_plugin/src/line_provider/asset_provider/file_extension_asset_provider_plugin.rs
+++ b/crates/bevy_plugin/src/line_provider/asset_provider/file_extension_asset_provider_plugin.rs
@@ -2,7 +2,7 @@ use crate::fmt_utils::SkipDebug;
 use crate::prelude::*;
 use crate::UnderlyingYarnLine;
 use bevy::asset::{LoadState, LoadedUntypedAsset};
-use bevy::platform_support::collections::{HashMap, HashSet};
+use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 use std::any::Any;
 use std::fmt::Debug;
@@ -50,7 +50,7 @@ pub struct FileExtensionAssetProvider {
 macro_rules! file_extensions {
     ($($type:ty: $ext:expr),* $(,)?) => {
         {
-            bevy::platform_support::collections::HashMap::from([
+            bevy::platform::collections::HashMap::from([
                 $(
                     (<$type as bevy::reflect::TypePath>::type_path(), $ext),
                 )*

--- a/crates/bevy_plugin/src/localization/line_id_generation.rs
+++ b/crates/bevy_plugin/src/localization/line_id_generation.rs
@@ -2,7 +2,7 @@ use crate::localization::UpdateAllStringsFilesForStringTableEvent;
 use crate::plugin::AssetRoot;
 use crate::prelude::*;
 use crate::project::{RecompileLoadedYarnFilesEvent, YarnFilesBeingLoaded};
-use bevy::platform_support::collections::HashSet;
+use bevy::platform::collections::HashSet;
 use bevy::prelude::*;
 use std::hash::Hash;
 

--- a/crates/bevy_plugin/src/localization/strings_file/asset.rs
+++ b/crates/bevy_plugin/src/localization/strings_file/asset.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 use anyhow::{anyhow, bail, Result};
 use bevy::asset::{io::Reader, AssetLoader, LoadContext};
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
 use sha2::{Digest, Sha256};

--- a/crates/bevy_plugin/src/localization/strings_file/updating.rs
+++ b/crates/bevy_plugin/src/localization/strings_file/updating.rs
@@ -1,6 +1,6 @@
 use crate::plugin::AssetRoot;
 use crate::{localization::line_id_generation::LineIdUpdateSystemSet, prelude::*};
-use bevy::platform_support::collections::{HashMap, HashSet};
+use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 
 pub(crate) fn strings_file_updating_plugin(app: &mut App) {

--- a/crates/bevy_plugin/src/project.rs
+++ b/crates/bevy_plugin/src/project.rs
@@ -27,7 +27,8 @@ pub(crate) struct CompilationSystemSet;
 /// app.add_systems(Update, setup_dialogue_runners.run_if(resource_added::<YarnProject>));
 ///
 /// fn setup_dialogue_runners(mut commands: Commands, project: Res<YarnProject>) {
-///    commands.spawn(project.create_dialogue_runner());
+///    let dialogue_runner = project.create_dialogue_runner(&mut commands);
+///    commands.spawn(dialogue_runner);
 /// }
 /// ```
 #[derive(Resource, Debug)]

--- a/crates/bevy_plugin/src/project.rs
+++ b/crates/bevy_plugin/src/project.rs
@@ -59,13 +59,13 @@ impl YarnProject {
 
     /// Constructs a [`DialogueRunner`] from this project using all defaults of [`DialogueRunnerBuilder`] .
     /// This is a convenience method for calling [`DialogueRunnerBuilder::build`] on an unconfigured builder returned by [`YarnProject::build_dialogue_runner`].
-    pub fn create_dialogue_runner(&self) -> DialogueRunner {
-        self.build_dialogue_runner().build()
+    pub fn create_dialogue_runner(&self, commands: &mut Commands) -> DialogueRunner {
+        self.build_dialogue_runner(commands).build()
     }
 
     /// Constructs a [`DialogueRunnerBuilder`] that can be used to customize the construction of a [`DialogueRunner`] from this project.
-    pub fn build_dialogue_runner(&self) -> DialogueRunnerBuilder {
-        DialogueRunnerBuilder::from_yarn_project(self)
+    pub fn build_dialogue_runner(&self, commands: &mut Commands) -> DialogueRunnerBuilder {
+        DialogueRunnerBuilder::from_yarn_project(self, commands)
     }
 
     /// Returns the metadata associated with the given [`LineId`], if any. This can also be accessed on a given [`LocalizedLine`] via its `metadata` field.

--- a/crates/bevy_plugin/src/project.rs
+++ b/crates/bevy_plugin/src/project.rs
@@ -1,6 +1,6 @@
 use crate::fmt_utils::SkipDebug;
 use crate::prelude::*;
-use bevy::platform_support::collections::{HashMap, HashSet};
+use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 pub(crate) use compilation::{
     RecompileLoadedYarnFilesEvent, YarnFilesBeingLoaded, YarnProjectConfigToLoad,

--- a/crates/bevy_plugin/src/project/compilation.rs
+++ b/crates/bevy_plugin/src/project/compilation.rs
@@ -4,7 +4,7 @@ use crate::plugin::AssetRoot;
 use crate::prelude::*;
 use crate::project::{CompilationSystemSet, LoadYarnProjectEvent, WatchingForChanges};
 use anyhow::{anyhow, bail, Result};
-use bevy::platform_support::collections::HashSet;
+use bevy::platform::collections::HashSet;
 use bevy::prelude::*;
 use std::fmt::Debug;
 

--- a/crates/bevy_plugin/tests/test_asset_provider.rs
+++ b/crates/bevy_plugin/tests/test_asset_provider.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "audio_assets")]
 use anyhow::{bail, Result};
-use bevy::platform_support::time::Instant;
+use bevy::platform::time::Instant;
 use bevy::prelude::*;
 use bevy_yarnspinner::prelude::*;
 use utils::prelude::*;

--- a/crates/bevy_plugin/tests/test_asset_provider.rs
+++ b/crates/bevy_plugin/tests/test_asset_provider.rs
@@ -10,6 +10,7 @@ mod utils;
 #[test]
 fn does_not_load_asset_without_localizations() -> Result<()> {
     let mut app = App::new();
+    let mut world = World::default();
 
     app.setup_default_plugins()
         .add_plugins(YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file(
@@ -18,7 +19,7 @@ fn does_not_load_asset_without_localizations() -> Result<()> {
 
     let project = app.load_project();
     let mut dialogue_runner = project
-        .build_dialogue_runner()
+        .build_dialogue_runner(&mut world.commands())
         .add_asset_provider(AudioAssetProvider::new())
         .build();
     dialogue_runner.start_node("Start");
@@ -43,6 +44,7 @@ fn does_not_load_asset_without_localizations() -> Result<()> {
 #[test]
 fn does_not_load_invalid_asset_id() -> Result<()> {
     let mut app = App::new();
+    let mut world = World::default();
 
     app.setup_default_plugins().add_plugins(
         YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file("lines_with_ids.yarn"))
@@ -55,7 +57,7 @@ fn does_not_load_invalid_asset_id() -> Result<()> {
 
     let project = app.load_project();
     let mut dialogue_runner = project
-        .build_dialogue_runner()
+        .build_dialogue_runner(&mut world.commands())
         .add_asset_provider(AudioAssetProvider::new())
         .build();
     dialogue_runner
@@ -73,6 +75,7 @@ fn does_not_load_invalid_asset_id() -> Result<()> {
 #[test]
 fn loads_asset_from_base_language_localization() -> Result<()> {
     let mut app = App::new();
+    let mut world = World::default();
 
     app.setup_default_plugins().add_plugins(
         YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file("lines_with_ids.yarn"))
@@ -85,7 +88,7 @@ fn loads_asset_from_base_language_localization() -> Result<()> {
 
     let project = app.load_project();
     let mut dialogue_runner = project
-        .build_dialogue_runner()
+        .build_dialogue_runner(&mut world.commands())
         .add_asset_provider(AudioAssetProvider::new())
         .build();
     dialogue_runner.start_node("Start");
@@ -107,6 +110,7 @@ fn loads_asset_from_base_language_localization() -> Result<()> {
 #[test]
 fn loads_asset_from_translated_localization() -> Result<()> {
     let mut app = App::new();
+    let mut world = World::default();
 
     app.setup_default_plugins().add_plugins(
         YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file("lines_with_ids.yarn"))
@@ -119,7 +123,7 @@ fn loads_asset_from_translated_localization() -> Result<()> {
 
     let project = app.load_project();
     let mut dialogue_runner = project
-        .build_dialogue_runner()
+        .build_dialogue_runner(&mut world.commands())
         .add_asset_provider(AudioAssetProvider::new())
         .build();
     dialogue_runner
@@ -143,6 +147,7 @@ fn loads_asset_from_translated_localization() -> Result<()> {
 #[should_panic]
 fn panics_on_invalid_language() {
     let mut app = App::new();
+    let mut world = World::default();
 
     app.setup_default_plugins().add_plugins(
         YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file("lines_with_ids.yarn"))
@@ -155,7 +160,7 @@ fn panics_on_invalid_language() {
 
     let project = app.load_project();
     let mut dialogue_runner = project
-        .build_dialogue_runner()
+        .build_dialogue_runner(&mut world.commands())
         .add_asset_provider(AudioAssetProvider::new())
         .build();
     dialogue_runner
@@ -168,6 +173,7 @@ fn panics_on_invalid_language() {
 #[test]
 fn does_not_load_asset_with_invalid_type() -> Result<()> {
     let mut app = App::new();
+    let mut world = World::default();
 
     app.setup_default_plugins().add_plugins(
         YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file("lines_with_ids.yarn"))
@@ -180,7 +186,7 @@ fn does_not_load_asset_with_invalid_type() -> Result<()> {
 
     let project = app.load_project();
     let mut dialogue_runner = project
-        .build_dialogue_runner()
+        .build_dialogue_runner(&mut world.commands())
         .add_asset_provider(AudioAssetProvider::new())
         .build();
 

--- a/crates/bevy_plugin/tests/test_dialogue_runner_delivers_lines.rs
+++ b/crates/bevy_plugin/tests/test_dialogue_runner_delivers_lines.rs
@@ -280,8 +280,7 @@ fn setup_dialogue_runner_with_localizations(app: &mut App) -> Mut<DialogueRunner
                 })
                 .with_development_file_generation(DevelopmentFileGeneration::None),
         )
-        .load_project()
-        .build_dialogue_runner();
+        .load_project_and_get_dialogue_bulider();
 
     #[cfg(feature = "audio_assets")]
     {

--- a/crates/bevy_plugin/tests/test_dialogue_runner_delivers_lines.rs
+++ b/crates/bevy_plugin/tests/test_dialogue_runner_delivers_lines.rs
@@ -280,7 +280,7 @@ fn setup_dialogue_runner_with_localizations(app: &mut App) -> Mut<DialogueRunner
                 })
                 .with_development_file_generation(DevelopmentFileGeneration::None),
         )
-        .load_project_and_get_dialogue_bulider();
+        .load_project_and_get_dialogue_builder();
 
     #[cfg(feature = "audio_assets")]
     {

--- a/crates/bevy_plugin/tests/test_dialogue_runner_runs_commands.rs
+++ b/crates/bevy_plugin/tests/test_dialogue_runner_runs_commands.rs
@@ -120,6 +120,7 @@ trait CommandAppExt {
 
 impl CommandAppExt for App {
     fn setup_dialogue_runner(&mut self) -> Mut<DialogueRunner> {
+        let mut world = World::default();
         let mut dialogue_runner = self
             .setup_default_plugins()
             .add_plugins(YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file(
@@ -128,9 +129,9 @@ impl CommandAppExt for App {
             .dialogue_runner_mut();
         dialogue_runner.commands_mut().add_command(
             "set_data",
-            |In(param): In<String>, mut commands: Commands| {
+            world.register_system(|In(param): In<String>, mut commands: Commands| {
                 commands.insert_resource(Data(param));
-            },
+            }),
         );
         dialogue_runner
             .library_mut()

--- a/crates/bevy_plugin/tests/test_dialogue_runner_runs_commands.rs
+++ b/crates/bevy_plugin/tests/test_dialogue_runner_runs_commands.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bevy::platform_support::time::Instant;
+use bevy::platform::time::Instant;
 use bevy::prelude::*;
 use bevy_yarnspinner::{events::*, prelude::*};
 use std::thread::sleep;

--- a/crates/bevy_plugin/tests/test_dialogue_runner_runs_commands.rs
+++ b/crates/bevy_plugin/tests/test_dialogue_runner_runs_commands.rs
@@ -120,19 +120,20 @@ trait CommandAppExt {
 
 impl CommandAppExt for App {
     fn setup_dialogue_runner(&mut self) -> Mut<DialogueRunner> {
-        let mut world = World::default();
+        let set_data =
+            self.world_mut()
+                .register_system(|In(param): In<String>, mut commands: Commands| {
+                    commands.insert_resource(Data(param));
+                });
         let mut dialogue_runner = self
             .setup_default_plugins()
             .add_plugins(YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file(
                 "commands.yarn",
             )))
             .dialogue_runner_mut();
-        dialogue_runner.commands_mut().add_command(
-            "set_data",
-            world.register_system(|In(param): In<String>, mut commands: Commands| {
-                commands.insert_resource(Data(param));
-            }),
-        );
+        dialogue_runner
+            .commands_mut()
+            .add_command("set_data", set_data);
         dialogue_runner
             .library_mut()
             .add_function("triplicate_data", |data: &str| {

--- a/crates/bevy_plugin/tests/test_dialogue_runner_runs_functions.rs
+++ b/crates/bevy_plugin/tests/test_dialogue_runner_runs_functions.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use bevy::prelude::*;
+use bevy_yarnspinner::{events::*, prelude::*};
+use utils::prelude::*;
+
+mod utils;
+
+#[test]
+fn basic_functions() -> Result<()> {
+    let mut app = App::new();
+    let mut asserter = EventAsserter::new();
+    let mut dialogue_runner = app.setup_dialogue_runner();
+    dialogue_runner.start_node("Start");
+    app.update();
+    assert_events!(asserter, app contains [
+        PresentLineEvent with |event| event.line.text == "Data = Initial",
+    ]);
+    app.continue_dialogue_and_update();
+    assert_events!(asserter, app contains [
+        PresentLineEvent with |event| event.line.text == "New Data = After Swap",
+    ]);
+    app.continue_dialogue_and_update();
+    assert_events!(asserter, app contains [
+        PresentLineEvent with |event| event.line.text == "Picky, picky: true",
+    ]);
+
+    Ok(())
+}
+
+#[derive(Debug, Resource)]
+struct Data(String);
+
+trait FunctionAppExt {
+    fn setup_dialogue_runner(&mut self) -> Mut<DialogueRunner>;
+}
+
+impl FunctionAppExt for App {
+    fn setup_dialogue_runner(&mut self) -> Mut<DialogueRunner> {
+        self.insert_resource(Data("Initial".to_string()));
+
+        let swap_data =
+            self.register_system(|In(param): In<String>, mut data: ResMut<Data>| -> String {
+                let old = data.0.clone();
+                data.0 = param;
+                old
+            });
+
+        self.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Name::new("Tweedledee"));
+        });
+
+        let picky_function = self.register_system(|_: Single<&Name>| -> bool { true });
+
+        let mut dialogue_runner = self
+            .setup_default_plugins()
+            .add_plugins(YarnSpinnerPlugin::with_yarn_source(YarnFileSource::file(
+                "functions.yarn",
+            )))
+            .dialogue_runner_mut();
+        dialogue_runner
+            .library_mut()
+            .add_function("swap_data", swap_data);
+        dialogue_runner
+            .library_mut()
+            .add_function("picky_function", picky_function);
+        dialogue_runner
+    }
+}

--- a/crates/bevy_plugin/tests/utils/mod.rs
+++ b/crates/bevy_plugin/tests/utils/mod.rs
@@ -106,6 +106,7 @@ impl AppExt for App {
                 SystemState::new(self.world_mut());
             let (mut commands, yarn_project) = system_state.get_mut(self.world_mut());
             let dialogue_runner = yarn_project.create_dialogue_runner(&mut commands);
+            system_state.apply(self.world_mut());
             self.world_mut().spawn(dialogue_runner).id()
         }
     }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarnspinner_compiler"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust"
 homepage = "https://docs.yarnspinner.dev/"
@@ -18,10 +18,10 @@ bevy = ["dep:bevy", "yarnspinner_core/bevy"]
 antlr-rust = "=0.3.0-beta"
 better_any = "=0.2.0"
 regex = "1"
-yarnspinner_core = { path = "../core", version = "0.5.0-rc" }
+yarnspinner_core = { path = "../core", version = "0.5.0" }
 annotate-snippets = "0.10"
 serde = { version = "1", features = ["derive"], optional = true }
-bevy = { version = "0.16.0-rc", default-features = false, optional = true }
+bevy = { version = "0.16.0", default-features = false, optional = true }
 rand = { version = "0.8", features = ["small_rng"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarnspinner_core"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust"
 homepage = "https://docs.yarnspinner.dev/"
@@ -17,7 +17,9 @@ bevy = ["dep:bevy"]
 [dependencies]
 prost = "0.12"
 serde = { version = "1", features = ["derive"], optional = true }
-bevy = { version = "0.16.0-rc", default-features = false, optional = true, features = ["std"] }
+bevy = { version = "0.16.0", default-features = false, optional = true, features = [
+    "std",
+] }
 variadics_please = "1.1.0"
 
 [dev-dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,3 +24,8 @@ variadics_please = "1.1.0"
 
 [dev-dependencies]
 static_assertions = "1.1.0"
+
+[lints.clippy]
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"

--- a/crates/core/src/generated/ext.rs
+++ b/crates/core/src/generated/ext.rs
@@ -1,8 +1,8 @@
 //! Contains extensions to generated types that in the original implementation are sprinkled around the repo via partial classes
 
 use crate::prelude::*;
-use std::error::Error;
-use std::fmt::{Debug, Display};
+use core::error::Error;
+use core::fmt::{Debug, Display};
 
 impl From<String> for Operand {
     fn from(s: String) -> Self {
@@ -107,7 +107,7 @@ pub struct InvalidOpCodeError(pub i32);
 impl Error for InvalidOpCodeError {}
 
 impl Display for InvalidOpCodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?} is not a valid OpCode", self.0)
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,8 @@ pub mod types;
 mod yarn_fn;
 mod yarn_value;
 
+extern crate alloc;
+
 pub mod prelude {
     //! Types and functions used all throughout the runtime and compiler.
     #[cfg(any(feature = "bevy", feature = "serde"))]

--- a/crates/core/src/library.rs
+++ b/crates/core/src/library.rs
@@ -1,8 +1,8 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Library.cs>
 
 use crate::prelude::*;
+use alloc::borrow::Cow;
 use core::fmt::Display;
-use std::borrow::Cow;
 use std::collections::hash_map;
 
 /// A collection of functions that can be called from Yarn scripts.

--- a/crates/core/src/library.rs
+++ b/crates/core/src/library.rs
@@ -1,9 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Library.cs>
 
 use crate::prelude::*;
+use core::fmt::Display;
 use std::borrow::Cow;
 use std::collections::hash_map;
-use std::fmt::Display;
 
 /// A collection of functions that can be called from Yarn scripts.
 ///
@@ -169,7 +169,7 @@ impl Library {
 }
 
 impl Display for Library {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut functions: Vec<_> = self.0.iter().collect();
         functions.sort_by_key(|(name, _)| name.to_string());
         writeln!(f, "{{")?;

--- a/crates/core/src/line_id.rs
+++ b/crates/core/src/line_id.rs
@@ -1,6 +1,6 @@
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
-use std::fmt::Display;
+use core::fmt::Display;
 
 /// The unique ID of a line in a Yarn script. In a Yarn script, line IDs look like this:
 /// ```text
@@ -33,7 +33,7 @@ impl AsRef<str> for LineId {
 }
 
 impl Display for LineId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/crates/core/src/operator.rs
+++ b/crates/core/src/operator.rs
@@ -1,7 +1,7 @@
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
+use alloc::borrow::Cow;
 use core::fmt;
-use std::borrow::Cow;
 
 /// The available operators that can be used with Yarn values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/types/boolean.rs
+++ b/crates/core/src/types/boolean.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use crate::types::TypeProperties;
-use std::ops::*;
+use core::ops::*;
 
 /// A type that bridges to [`bool`]
 pub(crate) fn boolean_type_properties() -> TypeProperties {

--- a/crates/core/src/types/function.rs
+++ b/crates/core/src/types/function.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 use crate::types::TypeProperties;
 use crate::types::{Type, TypeFormat};
-use std::fmt::Display;
+use core::fmt::Display;
 
 pub(crate) fn function_type_properties(function_type: &FunctionType) -> TypeProperties {
     TypeProperties::from_name("Function").with_description(function_type.to_string())
@@ -57,7 +57,7 @@ impl FunctionType {
 }
 
 impl Display for FunctionType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let parameters = self
             .parameters
             .iter()

--- a/crates/core/src/types/number.rs
+++ b/crates/core/src/types/number.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use crate::types::TypeProperties;
-use std::ops::*;
+use core::ops::*;
 
 /// A type that bridges to [`f32`]
 pub(crate) fn number_type_properties() -> TypeProperties {

--- a/crates/core/src/types/type.rs
+++ b/crates/core/src/types/type.rs
@@ -4,9 +4,9 @@ use crate::types::boolean::boolean_type_properties;
 use crate::types::number::number_type_properties;
 use crate::types::string::string_type_properties;
 use crate::types::*;
-use std::any::TypeId;
-use std::error::Error;
-use std::fmt::{Debug, Display};
+use core::any::TypeId;
+use core::error::Error;
+use core::fmt::{Debug, Display};
 
 /// All types in the virtual machine, both built-in, i.e. usable in Yarn scripts, and internal.
 ///
@@ -45,7 +45,7 @@ pub enum Type {
 }
 
 impl Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let name = self.name();
         match self {
             Type::Function(function) => Display::fmt(function, f),
@@ -244,7 +244,7 @@ pub enum InvalidDowncastError {
 impl Error for InvalidDowncastError {}
 
 impl Display for InvalidDowncastError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             InvalidDowncastError::InvalidTypeId(id) => {
                 write!(f, "Cannot convert TypeId {id:?} to a Yarn Spinner `Type`")

--- a/crates/core/src/yarn_fn/function_registry.rs
+++ b/crates/core/src/yarn_fn/function_registry.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
+use alloc::borrow::Cow;
 #[cfg(feature = "bevy")]
 use bevy::prelude::*;
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// A registry of functions that can be called from Yarn after they have been added via [`YarnFnRegistry::register_function`].

--- a/crates/core/src/yarn_fn/function_wrapping.rs
+++ b/crates/core/src/yarn_fn/function_wrapping.rs
@@ -223,9 +223,9 @@ macro_rules! count_tts {
 #[cfg(feature = "bevy")]
 mod bevy_functions {
     use super::*;
+    use alloc::collections::VecDeque;
     use bevy::ecs::system::SystemId;
     use bevy::prelude::*;
-    use std::collections::VecDeque;
 
     macro_rules! impl_yarn_fn_tuple_bevy {
         ($($yarn_param: ident),*) => {

--- a/crates/core/src/yarn_fn/function_wrapping.rs
+++ b/crates/core/src/yarn_fn/function_wrapping.rs
@@ -242,7 +242,8 @@ mod bevy_functions {
                         let mut input = VecDeque::from(input);
                         #[allow(unused)]
                         let input_len  = input.len();
-                        let expected_len = count_tts!($($yarn_param),*);
+                        let expected_len = count_tts!($($yarn_param) *);
+
                         assert!(input_len == expected_len, "YarnFn expected {expected_len} arguments but received {input_len}");
                         $(
                             let $yarn_param:$yarn_param = $yarn_param::try_from(input.pop_front().unwrap()).ok().expect("Invalid argument type");
@@ -440,6 +441,42 @@ mod tests {
             0
         }
         accept_yarn_fn(world.register_system(f));
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn can_call_degenerate_system() {
+        let mut world = World::default();
+        fn f() -> u32 {
+            42
+        }
+        let id = world.register_system(f);
+        let out = id.call(vec![], &mut world);
+        assert_eq!(out, 42);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn can_call_system_with_input() {
+        let mut world = World::default();
+        fn f(In(num): In<u32>) -> u32 {
+            num
+        }
+        let id = world.register_system(f);
+        let out = id.call(vec![YarnValue::from(42)], &mut world);
+        assert_eq!(out, 42);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn can_call_system_with_multiple_inputs() {
+        let mut world = World::default();
+        fn f(In((a, b)): In<(u32, u32)>, _: Query<Entity>) -> u32 {
+            a + b
+        }
+        let id = world.register_system(f);
+        let out = id.call(vec![YarnValue::from(40), YarnValue::from(2)], &mut world);
+        assert_eq!(out, 42);
     }
 
     #[test]

--- a/crates/core/src/yarn_fn/function_wrapping.rs
+++ b/crates/core/src/yarn_fn/function_wrapping.rs
@@ -2,9 +2,9 @@ use super::optionality::AllowedOptionalityChain;
 use crate::prelude::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
-use std::any::TypeId;
-use std::fmt::{Debug, Display, Formatter};
-use std::marker::PhantomData;
+use core::any::TypeId;
+use core::fmt::{Debug, Display, Formatter};
+use core::marker::PhantomData;
 use variadics_please::all_tuples;
 
 /// A function that can be registered into and called from Yarn.
@@ -168,9 +168,9 @@ impl<Marker, F> Debug for YarnFnWrapper<Marker, F>
 where
     F: YarnFn<Marker>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let signature = std::any::type_name::<Marker>();
-        let function_path = std::any::type_name::<F>();
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let signature = core::any::type_name::<Marker>();
+        let function_path = core::any::type_name::<F>();
         let debug_message = format!("{signature} {{{function_path}}}");
         f.debug_struct(&debug_message).finish()
     }
@@ -180,8 +180,8 @@ impl<Marker, F> Display for YarnFnWrapper<Marker, F>
 where
     F: YarnFn<Marker>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let signature = std::any::type_name::<Marker>();
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let signature = core::any::type_name::<Marker>();
         f.write_str(signature)
     }
 }

--- a/crates/core/src/yarn_fn/parameter_wrapping.rs
+++ b/crates/core/src/yarn_fn/parameter_wrapping.rs
@@ -1,15 +1,15 @@
-//! This helper code allows us to pass params to YarnFns by value (e.g. `usize`), by reference (e.g. (`&usize`) or by [`std::borrow::Borrow`] (e.g. `String` -> `&str`)
+//! This helper code allows us to pass params to YarnFns by value (e.g. `usize`), by reference (e.g. (`&usize`) or by [`core::borrow::Borrow`] (e.g. `String` -> `&str`)
 //!
 //! Inspired by <https://promethia-27.github.io/dependency_injection_like_bevy_from_scratch/chapter2/passing_references.html>
 
 use super::optionality::{AllowedOptionalityChain, Optional, Optionality, Required};
 use crate::prelude::*;
-use std::any::Any;
-use std::borrow::Borrow;
-use std::fmt::{Debug, Display};
-use std::iter::Peekable;
-use std::marker::PhantomData;
-use std::slice::IterMut;
+use core::any::Any;
+use core::borrow::Borrow;
+use core::fmt::{Debug, Display};
+use core::iter::Peekable;
+use core::marker::PhantomData;
+use core::slice::IterMut;
 use variadics_please::all_tuples;
 
 /// Helper class for implementing something like [`YarnFn`] yourself.
@@ -38,7 +38,7 @@ impl YarnValueWrapper {
         T: TryFrom<YarnValue> + 'static,
         <T as TryFrom<YarnValue>>::Error: Display,
     {
-        let raw = std::mem::take(&mut self.raw).unwrap();
+        let raw = core::mem::take(&mut self.raw).unwrap();
         let converted: T = raw
             .try_into()
             .unwrap_or_else(|e| panic!("Parameter passed to Yarn has invalid type: {e}"));

--- a/crates/core/src/yarn_fn/parameter_wrapping.rs
+++ b/crates/core/src/yarn_fn/parameter_wrapping.rs
@@ -4,13 +4,13 @@
 
 use super::optionality::{AllowedOptionalityChain, Optional, Optionality, Required};
 use crate::prelude::*;
-use std::any::Any;
-use std::any::TypeId;
-use std::borrow::Borrow;
-use std::fmt::{Debug, Display};
-use std::iter::Peekable;
-use std::marker::PhantomData;
-use std::slice::IterMut;
+use core::any::Any;
+use core::any::TypeId;
+use core::borrow::Borrow;
+use core::fmt::{Debug, Display};
+use core::iter::Peekable;
+use core::marker::PhantomData;
+use core::slice::IterMut;
 use variadics_please::all_tuples;
 
 /// Helper class for implementing something like [`YarnFn`] yourself.

--- a/crates/core/src/yarn_fn/parameter_wrapping.rs
+++ b/crates/core/src/yarn_fn/parameter_wrapping.rs
@@ -5,6 +5,7 @@
 use super::optionality::{AllowedOptionalityChain, Optional, Optionality, Required};
 use crate::prelude::*;
 use core::any::Any;
+use core::any::TypeId;
 use core::borrow::Borrow;
 use core::fmt::{Debug, Display};
 use core::iter::Peekable;
@@ -65,12 +66,15 @@ pub trait YarnFnParam {
 
     #[doc(hidden)]
     fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a>;
+
+    #[doc(hidden)]
+    fn parameter_types() -> Vec<TypeId>;
 }
 
 /// Shorthand way of accessing the associated type [`YarnFnParam::Item`] for a given [`YarnFnParam`].
 pub type YarnFnParamItem<'a, P> = <P as YarnFnParam>::Item<'a>;
 
-impl<T: YarnFnParam> YarnFnParam for Option<T> {
+impl<T: YarnFnParam + 'static> YarnFnParam for Option<T> {
     type Item<'new> = Option<T::Item<'new>>;
     type Optionality = Optional;
 
@@ -81,13 +85,17 @@ impl<T: YarnFnParam> YarnFnParam for Option<T> {
             None
         }
     }
+
+    fn parameter_types() -> Vec<TypeId> {
+        vec![TypeId::of::<Option<T>>()]
+    }
 }
 
 macro_rules! impl_yarn_fn_param_tuple {
     ($($param: ident),*) => {
         #[allow(non_snake_case)]
         impl<$($param,)*> YarnFnParam for ($($param,)*)
-            where $($param: YarnFnParam,)*
+            where $($param: YarnFnParam + 'static,)*
                   ($(<$param as YarnFnParam>::Optionality,)*): AllowedOptionalityChain
         {
             type Item<'new> = ($($param::Item<'new>,)*);
@@ -96,6 +104,10 @@ macro_rules! impl_yarn_fn_param_tuple {
             #[allow(unused_variables, clippy::unused_unit)] // for n = 0 tuples
             fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a> {
                ($($param::retrieve(iter),)*)
+            }
+
+            fn parameter_types() -> Vec<TypeId> {
+                vec![$(TypeId::of::<$param>()),*]
             }
         }
     };
@@ -129,6 +141,10 @@ where
             value,
             phantom_data: PhantomData,
         }
+    }
+
+    fn parameter_types() -> Vec<TypeId> {
+        vec![TypeId::of::<&T>()]
     }
 }
 
@@ -165,6 +181,10 @@ where
             phantom_data: PhantomData,
         }
     }
+
+    fn parameter_types() -> Vec<TypeId> {
+        vec![TypeId::of::<&U>()]
+    }
 }
 
 struct ResOwned<T>
@@ -190,6 +210,10 @@ where
         let value = *converted.downcast::<T>().unwrap();
         ResOwned { value }
     }
+
+    fn parameter_types() -> Vec<TypeId> {
+        vec![TypeId::of::<T>()]
+    }
 }
 
 macro_rules! impl_yarn_fn_param {
@@ -211,6 +235,10 @@ macro_rules! impl_yarn_fn_param_inner {
             fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a> {
                 ResRef::<$referenced>::retrieve(iter).value
             }
+
+            fn parameter_types() -> Vec<TypeId> {
+                vec![TypeId::of::<&$referenced>()]
+            }
         }
 
         impl YarnFnParam for $referenced {
@@ -219,6 +247,10 @@ macro_rules! impl_yarn_fn_param_inner {
 
             fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a> {
                 ResOwned::<$referenced>::retrieve(iter).value
+            }
+
+            fn parameter_types() -> Vec<TypeId> {
+                vec![TypeId::of::<$referenced>()]
             }
         }
     };
@@ -230,6 +262,10 @@ macro_rules! impl_yarn_fn_param_inner {
             fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a> {
                 ResRefBorrow::<$owned, $referenced>::retrieve(iter).value
             }
+
+            fn parameter_types() -> Vec<TypeId> {
+                vec![TypeId::of::<&$referenced>()]
+            }
         }
 
         impl YarnFnParam for &$owned {
@@ -239,6 +275,10 @@ macro_rules! impl_yarn_fn_param_inner {
             fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a> {
                 ResRef::<$owned>::retrieve(iter).value
             }
+
+            fn parameter_types() -> Vec<TypeId> {
+                vec![TypeId::of::<&$owned>()]
+            }
         }
 
         impl YarnFnParam for $owned {
@@ -247,6 +287,10 @@ macro_rules! impl_yarn_fn_param_inner {
 
             fn retrieve<'a>(iter: &mut YarnValueWrapperIter<'a>) -> Self::Item<'a> {
                 ResOwned::<$owned>::retrieve(iter).value
+            }
+
+            fn parameter_types() -> Vec<TypeId> {
+                vec![TypeId::of::<$owned>()]
             }
         }
     };

--- a/crates/core/src/yarn_fn/parameter_wrapping.rs
+++ b/crates/core/src/yarn_fn/parameter_wrapping.rs
@@ -4,13 +4,13 @@
 
 use super::optionality::{AllowedOptionalityChain, Optional, Optionality, Required};
 use crate::prelude::*;
-use core::any::Any;
-use core::any::TypeId;
-use core::borrow::Borrow;
-use core::fmt::{Debug, Display};
-use core::iter::Peekable;
-use core::marker::PhantomData;
-use core::slice::IterMut;
+use std::any::Any;
+use std::any::TypeId;
+use std::borrow::Borrow;
+use std::fmt::{Debug, Display};
+use std::iter::Peekable;
+use std::marker::PhantomData;
+use std::slice::IterMut;
 use variadics_please::all_tuples;
 
 /// Helper class for implementing something like [`YarnFn`] yourself.

--- a/crates/core/src/yarn_value.rs
+++ b/crates/core/src/yarn_value.rs
@@ -1,8 +1,8 @@
 //! Implements a subset of dotnet's [`Convert`](https://learn.microsoft.com/en-us/dotnet/api/system.convert?view=net-8.0) type.
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use core::error::Error;
+use core::fmt::{Display, Formatter};
 
 /// Represents a Yarn value. The chosen variant corresponds to the last assignment of the value,
 /// with the type being inferred from the type checker.
@@ -208,9 +208,9 @@ impl IntoYarnValueFromNonYarnValue for bool {
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub enum YarnValueCastError {
-    ParseFloatError(std::num::ParseFloatError),
-    ParseIntError(std::num::ParseIntError),
-    ParseBoolError(std::str::ParseBoolError),
+    ParseFloatError(core::num::ParseFloatError),
+    ParseIntError(core::num::ParseIntError),
+    ParseBoolError(core::str::ParseBoolError),
 }
 
 impl Error for YarnValueCastError {
@@ -224,7 +224,7 @@ impl Error for YarnValueCastError {
 }
 
 impl Display for YarnValueCastError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             YarnValueCastError::ParseFloatError(e) => Display::fmt(e, f),
             YarnValueCastError::ParseIntError(e) => Display::fmt(e, f),
@@ -233,26 +233,26 @@ impl Display for YarnValueCastError {
     }
 }
 
-impl From<std::num::ParseFloatError> for YarnValueCastError {
-    fn from(value: std::num::ParseFloatError) -> Self {
+impl From<core::num::ParseFloatError> for YarnValueCastError {
+    fn from(value: core::num::ParseFloatError) -> Self {
         Self::ParseFloatError(value)
     }
 }
 
-impl From<std::num::ParseIntError> for YarnValueCastError {
-    fn from(value: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for YarnValueCastError {
+    fn from(value: core::num::ParseIntError) -> Self {
         Self::ParseIntError(value)
     }
 }
 
-impl From<std::str::ParseBoolError> for YarnValueCastError {
-    fn from(value: std::str::ParseBoolError) -> Self {
+impl From<core::str::ParseBoolError> for YarnValueCastError {
+    fn from(value: core::str::ParseBoolError) -> Self {
         Self::ParseBoolError(value)
     }
 }
 
 impl Display for YarnValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Number(value) => write!(f, "{value}"),
             Self::String(value) => write!(f, "{value}"),

--- a/crates/example_dialogue_view/Cargo.toml
+++ b/crates/example_dialogue_view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_yarnspinner_example_dialogue_view"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust"
 homepage = "https://docs.yarnspinner.dev/"
@@ -14,11 +14,11 @@ readme = "../../readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_yarnspinner = { path = "../bevy_plugin", version = "0.5.0-rc" }
+bevy_yarnspinner = { path = "../bevy_plugin", version = "0.5.0" }
 unicode-segmentation = "1"
 
 [dependencies.bevy]
-version = "0.16.0-rc"
+version = "0.16.0"
 default-features = false
 features = [
     "bevy_ui",

--- a/crates/example_dialogue_view/src/option_selection.rs
+++ b/crates/example_dialogue_view/src/option_selection.rs
@@ -2,7 +2,7 @@ use crate::setup::{spawn_options, DialogueNode, OptionButton, OptionsNode, UiRoo
 use crate::typewriter::{self, Typewriter, TypewriterFinishedEvent};
 use crate::ExampleYarnSpinnerDialogueViewSystemSet;
 use bevy::color::palettes::css;
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy::window::{PrimaryWindow, SystemCursorIcon};
 use bevy::winit::cursor::CursorIcon;

--- a/crates/example_dialogue_view/src/typewriter.rs
+++ b/crates/example_dialogue_view/src/typewriter.rs
@@ -2,7 +2,7 @@ use crate::option_selection::OptionSelection;
 use crate::setup::{create_dialog_text, DialogueContinueNode, DialogueNode, UiRootNode};
 use crate::updating::SpeakerChangeEvent;
 use crate::ExampleYarnSpinnerDialogueViewSystemSet;
-use bevy::platform_support::time::Instant;
+use bevy::platform::time::Instant;
 use bevy::prelude::*;
 use bevy_yarnspinner::{events::*, prelude::*};
 use unicode_segmentation::UnicodeSegmentation;

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarnspinner_runtime"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust"
 homepage = "https://docs.yarnspinner.dev/"
@@ -20,7 +20,7 @@ serde = [
 bevy = ["dep:bevy", "yarnspinner_core/bevy"]
 
 [dependencies]
-yarnspinner_core = { path = "../core", version = "0.5.0-rc" }
+yarnspinner_core = { path = "../core", version = "0.5.0" }
 unicode-normalization = "0.1"
 unicode-segmentation = "1"
 log = "0.4"
@@ -30,4 +30,4 @@ fixed_decimal = { version = "0.5", features = ["ryu", "std"] }
 once_cell = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"], optional = true }
-bevy = { version = "0.16.0-rc", default-features = false, optional = true }
+bevy = { version = "0.16.0", default-features = false, optional = true }

--- a/crates/yarnspinner/Cargo.toml
+++ b/crates/yarnspinner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarnspinner"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust"
 homepage = "https://docs.yarnspinner.dev/"
@@ -28,11 +28,11 @@ bevy = [
 ]
 
 [dependencies]
-yarnspinner_core = { path = "../core", version = "0.5.0-rc" }
-yarnspinner_compiler = { path = "../compiler", version = "0.5.0-rc" }
-yarnspinner_runtime = { path = "../runtime", version = "0.5.0-rc" }
+yarnspinner_core = { path = "../core", version = "0.5.0" }
+yarnspinner_compiler = { path = "../compiler", version = "0.5.0" }
+yarnspinner_runtime = { path = "../runtime", version = "0.5.0" }
 log = { version = "0.4", features = ["std"] }
-bevy = { version = "0.16.0-rc", default-features = false, optional = true }
+bevy = { version = "0.16.0", default-features = false, optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -11,8 +11,7 @@ description = "A demo for Bevy Yarn Spinner for Rust, the friendly tool for writ
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.16.0-rc" }
-bevy_yarnspinner = { path = "../crates/bevy_plugin", version = "0.5.0-rc.1" }
-bevy_yarnspinner_example_dialogue_view = { path = "../crates/example_dialogue_view", version = "0.5.0-rc.1" }
-# Patch needed until https://github.com/FraserLee/bevy_sprite3d/pull/32 is merged
-bevy_sprite3d = { version = "5.0.0-rc", git = "https://github.com/Caudiciform-Studios/bevy_sprite3d.git"}
+bevy = { version = "0.16.0" }
+bevy_yarnspinner = { path = "../crates/bevy_plugin", version = "0.5.0" }
+bevy_yarnspinner_example_dialogue_view = { path = "../crates/example_dialogue_view", version = "0.5.0" }
+bevy_sprite3d = { version = "5.0.0-rc.1", git = "https://github.com/extrawurst/bevy_sprite3d.git", branch = "bevy-0.16" }

--- a/demo/src/easing.rs
+++ b/demo/src/easing.rs
@@ -1,4 +1,4 @@
-use bevy::platform_support::time::Instant;
+use bevy::platform::time::Instant;
 use bevy::prelude::*;
 use std::f32::consts::PI;
 use std::fmt::Debug;

--- a/demo/src/setup.rs
+++ b/demo/src/setup.rs
@@ -107,7 +107,10 @@ pub(crate) fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnPro
         .add_command("fade_out", commands.register_system(fade_out))
         .add_command("quit", commands.register_system(quit))
         .add_command("rotate", commands.register_system(rotate_character))
-        .add_command("move_camera_to_clippy", commands.register_system(move_camera_to_clippy))
+        .add_command(
+            "move_camera_to_clippy",
+            commands.register_system(move_camera_to_clippy),
+        )
         .add_command("show_bang", commands.register_system(show_bang));
     // Immediately start showing the dialogue
     dialogue_runner.start_node("Start");

--- a/demo/src/setup.rs
+++ b/demo/src/setup.rs
@@ -99,16 +99,16 @@ pub(crate) fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 pub(crate) fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
-    let mut dialogue_runner = project.create_dialogue_runner();
+    let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
     dialogue_runner
         .commands_mut()
-        .add_command("change_sprite", change_sprite)
-        .add_command("fade_in", fade_in)
-        .add_command("fade_out", fade_out)
-        .add_command("quit", quit)
-        .add_command("rotate", rotate_character)
-        .add_command("move_camera_to_clippy", move_camera_to_clippy)
-        .add_command("show_bang", show_bang);
+        .add_command("change_sprite", commands.register_system(change_sprite))
+        .add_command("fade_in", commands.register_system(fade_in))
+        .add_command("fade_out", commands.register_system(fade_out))
+        .add_command("quit", commands.register_system(quit))
+        .add_command("rotate", commands.register_system(rotate_character))
+        .add_command("move_camera_to_clippy", commands.register_system(move_camera_to_clippy))
+        .add_command("show_bang", commands.register_system(show_bang));
     // Immediately start showing the dialogue
     dialogue_runner.start_node("Start");
     commands.spawn(dialogue_runner);

--- a/demo/src/yarnspinner_integration.rs
+++ b/demo/src/yarnspinner_integration.rs
@@ -57,7 +57,7 @@ pub(crate) fn change_speaker(
 }
 
 pub(crate) fn change_sprite(
-    In((character, sprite)): In<(&str, &str)>,
+    In((character, sprite)): In<(String, String)>,
     mut speakers: Query<(&Speaker, &Transform, &mut RotationPhase)>,
     camera_transform: Single<&Transform, (With<MainCamera>, Without<RotationPhase>)>,
     sprites: Res<Sprites>,
@@ -66,7 +66,7 @@ pub(crate) fn change_sprite(
         .iter_mut()
         .find(|(speaker, ..)| speaker.name.to_lowercase() == character.to_lowercase())
         .unwrap();
-    let new_sprite = match sprite {
+    let new_sprite = match sprite.as_str() {
         "ferris_neutral" => Some(sprites.ferris_neutral.clone()),
         "ferris_happy" => Some(sprites.ferris_happy.clone()),
         "clippy" => Some(sprites.clippy.clone()),
@@ -90,12 +90,12 @@ pub(crate) fn change_sprite(
 }
 
 pub(crate) fn rotate_character(
-    In(character): In<&str>,
+    In(character): In<String>,
     speakers: Query<(&Speaker, &Transform, &mut RotationPhase)>,
     camera: Single<&Transform, (With<MainCamera>, Without<RotationPhase>)>,
     sprites: Res<Sprites>,
 ) {
-    change_sprite(In((character, "")), speakers, camera, sprites);
+    change_sprite(In((character, "".to_string())), speakers, camera, sprites);
 }
 
 pub(crate) fn fade_in(
@@ -142,7 +142,7 @@ pub(crate) fn move_camera_to_clippy(_: In<()>, mut commands: Commands) -> Arc<At
 }
 
 pub(crate) fn show_bang(
-    In((character, duration)): In<(&str, f32)>,
+    In((character, duration)): In<(String, f32)>,
     speakers: Query<&Speaker>,
     mut commands: Commands,
     mut sprite_params: Sprite3dParams,

--- a/demo/src/yarnspinner_integration.rs
+++ b/demo/src/yarnspinner_integration.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bevy::app::AppExit;
 use bevy::pbr::NotShadowCaster;
-use bevy::platform_support::time::Instant;
+use bevy::platform::time::Instant;
 use bevy::prelude::*;
 use bevy_sprite3d::{Sprite3dBuilder, Sprite3dParams};
 use bevy_yarnspinner_example_dialogue_view::prelude::*;

--- a/examples/bevy_yarnspinner/Cargo.toml
+++ b/examples/bevy_yarnspinner/Cargo.toml
@@ -10,9 +10,9 @@ authors = ["Jan Hohenheim <jan@hohenheim.ch>"]
 publish = false
 
 [dependencies]
-bevy = { version = "0.16.0-rc", features = ["file_watcher"] }
-bevy_yarnspinner = { path = "../../crates/bevy_plugin", version = "0.5.0-rc" }
-bevy_yarnspinner_example_dialogue_view = { path = "../../crates/example_dialogue_view", version = "0.5.0-rc" }
+bevy = { version = "0.16.0", features = ["file_watcher"] }
+bevy_yarnspinner = { path = "../../crates/bevy_plugin", version = "0.5.0" }
+bevy_yarnspinner_example_dialogue_view = { path = "../../crates/example_dialogue_view", version = "0.5.0" }
 
 [[bin]]
 name = "access_variables"

--- a/examples/bevy_yarnspinner/src/bin/access_variables.rs
+++ b/examples/bevy_yarnspinner/src/bin/access_variables.rs
@@ -26,7 +26,7 @@ fn setup_camera(mut commands: Commands) {
 }
 
 fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
-    let mut dialogue_runner = project.create_dialogue_runner();
+    let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
     dialogue_runner.start_node("AccessVariables");
     commands.spawn(dialogue_runner);
 }

--- a/examples/bevy_yarnspinner/src/bin/custom_command.rs
+++ b/examples/bevy_yarnspinner/src/bin/custom_command.rs
@@ -23,13 +23,13 @@ fn setup_camera(mut commands: Commands) {
 }
 
 fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
-    let mut dialogue_runner = project.create_dialogue_runner();
+    let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
     // Add our custom commands to the dialogue runner
     dialogue_runner
         .commands_mut()
-        .add_command("insert_resource", insert_resource)
-        .add_command("update_resource", update_resource)
-        .add_command("read_resource", read_resource);
+        .add_command("insert_resource", commands.register_system(insert_resource))
+        .add_command("update_resource", commands.register_system(update_resource))
+        .add_command("read_resource", commands.register_system(read_resource));
     dialogue_runner.start_node("CustomCommand");
     commands.spawn(dialogue_runner);
 }

--- a/examples/bevy_yarnspinner/src/bin/custom_function.rs
+++ b/examples/bevy_yarnspinner/src/bin/custom_function.rs
@@ -27,7 +27,7 @@ fn setup_camera(mut commands: Commands) {
 }
 
 fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
-    let mut dialogue_runner = project.create_dialogue_runner();
+    let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
     // Add our custom function to the dialogue runner
     dialogue_runner.library_mut().add_function("pow", pow);
     dialogue_runner

--- a/examples/bevy_yarnspinner/src/bin/hello_world.rs
+++ b/examples/bevy_yarnspinner/src/bin/hello_world.rs
@@ -28,7 +28,7 @@ fn setup_camera(mut commands: Commands) {
 
 fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
     // Create a dialogue runner from the project.
-    let mut dialogue_runner = project.create_dialogue_runner();
+    let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
     // Immediately start showing the dialogue to the player
     dialogue_runner.start_node("HelloWorld");
     commands.spawn(dialogue_runner);

--- a/examples/yarnspinner_without_bevy/Cargo.toml
+++ b/examples/yarnspinner_without_bevy/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 crossterm = "0.27"
 ratatui = "0.26"
 anyhow = "1.0"
-yarnspinner = { path = "../../crates/yarnspinner", version = "0.5.0-rc" }
+yarnspinner = { path = "../../crates/yarnspinner", version = "0.5.0" }
 
 [[bin]]
 name = "access_variables"

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ fn setup_camera(mut commands: Commands) {
 
 fn spawn_dialogue_runner(mut commands: Commands, project: Res<YarnProject>) {
     // Create a dialogue runner from the project.
-    let mut dialogue_runner = project.create_dialogue_runner();
+    let mut dialogue_runner = project.create_dialogue_runner(&mut commands);
     // Immediately start showing the dialogue to the player
     dialogue_runner.start_node("HelloWorld");
     commands.spawn(dialogue_runner);

--- a/readme.md
+++ b/readme.md
@@ -106,10 +106,10 @@ Et voilà! That was all. Thanks for checking out Yarn Spinner for Rust! Continui
 
 ## Version Table
 
-| Bevy        | Yarn Spinner for Rust | 
-|-------------|-----------------------|
-| 0.16.0-rc   | 0.5.0-rc              |
-| 0.15        | 0.4                   |
-| 0.14        | 0.3                   |
-| 0.13        | 0.2                   |
-| 0.12        | 0.1                   |
+| Bevy        | Yarn Spinner for Rust                | 
+|-------------|------------------------------------- |
+| 0.16        | 0.5 (unreleased, but there's an RC)  |
+| 0.15        | 0.4                                  |
+| 0.14        | 0.3                                  |
+| 0.13        | 0.2                                  |
+| 0.12        | 0.1                                  |


### PR DESCRIPTION
Moving Commands to use registered systems and unifying the types that bevy yarn function systems and bevy yarn commands accept as parameters.

# Release Notes:

Yarn commands have been changed from adhoc `System`-like functions to registered Bevy `System`s. This allows for a cleaner definition (ie. commands with no arguments no longer have to have a `In<()>` parameter) and Bevy can now cache system data for commands. In particular `Local<..>` type system parameters will preserve their state between invocations which was not the case before.

## Updating:

Commands with `In<()>` parameters can remove those:

```rust
fn my_command(_: In<()>) {
...
}
```
Becomes just:
```rust
fn my_command() {
...
}
```

Since commands are now full fledged systems they must be registered with the Bevy `World` before being added to the Yarn command registry. The easiest way to do this is with a setup system:

```rust
app.add_systems(Startup, setup);
...

fn my_command() {
...
}

fn setup(mut commands: Commands, project: Res<YarnProject>) {
    dialogue_runner
         .commands_mut()
         .add_command("my_command", commands.register_system(my_command));
}
```
