### PR TITLE
Use core imports in core

### DIFF
--- a/crates/core/src/generated/ext.rs
+++ b/crates/core/src/generated/ext.rs
@@ -1,8 +1,8 @@
 //! Contains extensions to generated types that in the original implementation are sprinkled around the repo via partial classes
 
 use crate::prelude::*;
-use std::error::Error;
-use std::fmt::{Debug, Display};
+use core::error::Error;
+use core::fmt::{Debug, Display};
 
 impl From<String> for Operand {
     fn from(s: String) -> Self {
@@ -107,7 +107,7 @@ pub struct InvalidOpCodeError(pub i32);
 impl Error for InvalidOpCodeError {}
 
 impl Display for InvalidOpCodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?} is not a valid OpCode", self.0)
     }
 }

--- a/crates/core/src/library.rs
+++ b/crates/core/src/library.rs
@@ -1,9 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Library.cs>
 
 use crate::prelude::*;
+use core::fmt::Display;
 use std::borrow::Cow;
 use std::collections::hash_map;
-use std::fmt::Display;
 
 /// A collection of functions that can be called from Yarn scripts.
 ///
@@ -169,7 +169,7 @@ impl Library {
 }
 
 impl Display for Library {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut functions: Vec<_> = self.0.iter().collect();
         functions.sort_by_key(|(name, _)| name.to_string());
         writeln!(f, "{{")?;

--- a/crates/core/src/line_id.rs
+++ b/crates/core/src/line_id.rs
@@ -1,6 +1,6 @@
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
-use std::fmt::Display;
+use core::fmt::Display;
 
 /// The unique ID of a line in a Yarn script. In a Yarn script, line IDs look like this:
 /// ```text
@@ -33,7 +33,7 @@ impl AsRef<str> for LineId {
 }
 
 impl Display for LineId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/crates/core/src/types/boolean.rs
+++ b/crates/core/src/types/boolean.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use crate::types::TypeProperties;
-use std::ops::*;
+use core::ops::*;
 
 /// A type that bridges to [`bool`]
 pub(crate) fn boolean_type_properties() -> TypeProperties {

--- a/crates/core/src/types/function.rs
+++ b/crates/core/src/types/function.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 use crate::types::TypeProperties;
 use crate::types::{Type, TypeFormat};
-use std::fmt::Display;
+use core::fmt::Display;
 
 pub(crate) fn function_type_properties(function_type: &FunctionType) -> TypeProperties {
     TypeProperties::from_name("Function").with_description(function_type.to_string())
@@ -57,7 +57,7 @@ impl FunctionType {
 }
 
 impl Display for FunctionType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let parameters = self
             .parameters
             .iter()

--- a/crates/core/src/types/number.rs
+++ b/crates/core/src/types/number.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use crate::types::TypeProperties;
-use std::ops::*;
+use core::ops::*;
 
 /// A type that bridges to [`f32`]
 pub(crate) fn number_type_properties() -> TypeProperties {

--- a/crates/core/src/types/type.rs
+++ b/crates/core/src/types/type.rs
@@ -4,9 +4,9 @@ use crate::types::boolean::boolean_type_properties;
 use crate::types::number::number_type_properties;
 use crate::types::string::string_type_properties;
 use crate::types::*;
-use std::any::TypeId;
-use std::error::Error;
-use std::fmt::{Debug, Display};
+use core::any::TypeId;
+use core::error::Error;
+use core::fmt::{Debug, Display};
 
 /// All types in the virtual machine, both built-in, i.e. usable in Yarn scripts, and internal.
 ///
@@ -45,7 +45,7 @@ pub enum Type {
 }
 
 impl Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let name = self.name();
         match self {
             Type::Function(function) => Display::fmt(function, f),
@@ -244,7 +244,7 @@ pub enum InvalidDowncastError {
 impl Error for InvalidDowncastError {}
 
 impl Display for InvalidDowncastError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             InvalidDowncastError::InvalidTypeId(id) => {
                 write!(f, "Cannot convert TypeId {id:?} to a Yarn Spinner `Type`")

--- a/crates/core/src/yarn_fn/function_wrapping.rs
+++ b/crates/core/src/yarn_fn/function_wrapping.rs
@@ -2,9 +2,9 @@ use super::optionality::AllowedOptionalityChain;
 use crate::prelude::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
-use std::any::TypeId;
-use std::fmt::{Debug, Display, Formatter};
-use std::marker::PhantomData;
+use core::any::TypeId;
+use core::fmt::{Debug, Display, Formatter};
+use core::marker::PhantomData;
 use variadics_please::all_tuples;
 
 /// A function that can be registered into and called from Yarn.
@@ -168,9 +168,9 @@ impl<Marker, F> Debug for YarnFnWrapper<Marker, F>
 where
     F: YarnFn<Marker>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let signature = std::any::type_name::<Marker>();
-        let function_path = std::any::type_name::<F>();
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let signature = core::any::type_name::<Marker>();
+        let function_path = core::any::type_name::<F>();
         let debug_message = format!("{signature} {{{function_path}}}");
         f.debug_struct(&debug_message).finish()
     }
@@ -180,8 +180,8 @@ impl<Marker, F> Display for YarnFnWrapper<Marker, F>
 where
     F: YarnFn<Marker>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let signature = std::any::type_name::<Marker>();
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let signature = core::any::type_name::<Marker>();
         f.write_str(signature)
     }
 }

--- a/crates/core/src/yarn_fn/parameter_wrapping.rs
+++ b/crates/core/src/yarn_fn/parameter_wrapping.rs
@@ -1,15 +1,15 @@
-//! This helper code allows us to pass params to YarnFns by value (e.g. `usize`), by reference (e.g. (`&usize`) or by [`std::borrow::Borrow`] (e.g. `String` -> `&str`)
+//! This helper code allows us to pass params to YarnFns by value (e.g. `usize`), by reference (e.g. (`&usize`) or by [`core::borrow::Borrow`] (e.g. `String` -> `&str`)
 //!
 //! Inspired by <https://promethia-27.github.io/dependency_injection_like_bevy_from_scratch/chapter2/passing_references.html>
 
 use super::optionality::{AllowedOptionalityChain, Optional, Optionality, Required};
 use crate::prelude::*;
-use std::any::Any;
-use std::borrow::Borrow;
-use std::fmt::{Debug, Display};
-use std::iter::Peekable;
-use std::marker::PhantomData;
-use std::slice::IterMut;
+use core::any::Any;
+use core::borrow::Borrow;
+use core::fmt::{Debug, Display};
+use core::iter::Peekable;
+use core::marker::PhantomData;
+use core::slice::IterMut;
 use variadics_please::all_tuples;
 
 /// Helper class for implementing something like [`YarnFn`] yourself.
@@ -38,7 +38,7 @@ impl YarnValueWrapper {
         T: TryFrom<YarnValue> + 'static,
         <T as TryFrom<YarnValue>>::Error: Display,
     {
-        let raw = std::mem::take(&mut self.raw).unwrap();
+        let raw = core::mem::take(&mut self.raw).unwrap();
         let converted: T = raw
             .try_into()
             .unwrap_or_else(|e| panic!("Parameter passed to Yarn has invalid type: {e}"));

--- a/crates/core/src/yarn_value.rs
+++ b/crates/core/src/yarn_value.rs
@@ -1,8 +1,8 @@
 //! Implements a subset of dotnet's [`Convert`](https://learn.microsoft.com/en-us/dotnet/api/system.convert?view=net-8.0) type.
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use core::error::Error;
+use core::fmt::{Display, Formatter};
 
 /// Represents a Yarn value. The chosen variant corresponds to the last assignment of the value,
 /// with the type being inferred from the type checker.
@@ -208,9 +208,9 @@ impl IntoYarnValueFromNonYarnValue for bool {
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub enum YarnValueCastError {
-    ParseFloatError(std::num::ParseFloatError),
-    ParseIntError(std::num::ParseIntError),
-    ParseBoolError(std::str::ParseBoolError),
+    ParseFloatError(core::num::ParseFloatError),
+    ParseIntError(core::num::ParseIntError),
+    ParseBoolError(core::str::ParseBoolError),
 }
 
 impl Error for YarnValueCastError {
@@ -224,7 +224,7 @@ impl Error for YarnValueCastError {
 }
 
 impl Display for YarnValueCastError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             YarnValueCastError::ParseFloatError(e) => Display::fmt(e, f),
             YarnValueCastError::ParseIntError(e) => Display::fmt(e, f),
@@ -233,26 +233,26 @@ impl Display for YarnValueCastError {
     }
 }
 
-impl From<std::num::ParseFloatError> for YarnValueCastError {
-    fn from(value: std::num::ParseFloatError) -> Self {
+impl From<core::num::ParseFloatError> for YarnValueCastError {
+    fn from(value: core::num::ParseFloatError) -> Self {
         Self::ParseFloatError(value)
     }
 }
 
-impl From<std::num::ParseIntError> for YarnValueCastError {
-    fn from(value: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for YarnValueCastError {
+    fn from(value: core::num::ParseIntError) -> Self {
         Self::ParseIntError(value)
     }
 }
 
-impl From<std::str::ParseBoolError> for YarnValueCastError {
-    fn from(value: std::str::ParseBoolError) -> Self {
+impl From<core::str::ParseBoolError> for YarnValueCastError {
+    fn from(value: core::str::ParseBoolError) -> Self {
         Self::ParseBoolError(value)
     }
 }
 
 impl Display for YarnValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Number(value) => write!(f, "{value}"),
             Self::String(value) => write!(f, "{value}"),


### PR DESCRIPTION
Replaces std imports with core equivalents where possible - a small step toward no_std compatibility for embedded systems  and WASM targets

related #232 