### PR TITLE
Core should use alloc

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,3 +24,8 @@ variadics_please = "1.1.0"
 
 [dev-dependencies]
 static_assertions = "1.1.0"
+
+[lints.clippy]
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,8 @@ pub mod types;
 mod yarn_fn;
 mod yarn_value;
 
+extern crate alloc;
+
 pub mod prelude {
     //! Types and functions used all throughout the runtime and compiler.
     #[cfg(any(feature = "bevy", feature = "serde"))]

--- a/crates/core/src/library.rs
+++ b/crates/core/src/library.rs
@@ -1,8 +1,8 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Library.cs>
 
 use crate::prelude::*;
+use alloc::borrow::Cow;
 use core::fmt::Display;
-use std::borrow::Cow;
 use std::collections::hash_map;
 
 /// A collection of functions that can be called from Yarn scripts.

--- a/crates/core/src/operator.rs
+++ b/crates/core/src/operator.rs
@@ -1,7 +1,7 @@
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
+use alloc::borrow::Cow;
 use core::fmt;
-use std::borrow::Cow;
 
 /// The available operators that can be used with Yarn values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/yarn_fn/function_registry.rs
+++ b/crates/core/src/yarn_fn/function_registry.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
+use alloc::borrow::Cow;
 #[cfg(feature = "bevy")]
 use bevy::prelude::*;
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// A registry of functions that can be called from Yarn after they have been added via [`YarnFnRegistry::register_function`].

--- a/crates/core/src/yarn_fn/function_wrapping.rs
+++ b/crates/core/src/yarn_fn/function_wrapping.rs
@@ -223,9 +223,9 @@ macro_rules! count_tts {
 #[cfg(feature = "bevy")]
 mod bevy_functions {
     use super::*;
+    use alloc::collections::VecDeque;
     use bevy::ecs::system::SystemId;
     use bevy::prelude::*;
-    use alloc::collections::VecDeque;
 
     macro_rules! impl_yarn_fn_tuple_bevy {
         ($($yarn_param: ident),*) => {

--- a/crates/core/src/yarn_fn/function_wrapping.rs
+++ b/crates/core/src/yarn_fn/function_wrapping.rs
@@ -225,7 +225,7 @@ mod bevy_functions {
     use super::*;
     use bevy::ecs::system::SystemId;
     use bevy::prelude::*;
-    use std::collections::VecDeque;
+    use alloc::collections::VecDeque;
 
     macro_rules! impl_yarn_fn_tuple_bevy {
         ($($yarn_param: ident),*) => {


### PR DESCRIPTION
This adds a couple of lints as well that should fail CI when contributors accidentally rely on std

progress toward #232 