### PR TITLE
Use core types where possible in runtime

### DIFF
--- a/crates/runtime/src/analyser.rs
+++ b/crates/runtime/src/analyser.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use self::default_analysers::*;
 pub use self::{context::*, diagnosis::*};
-use std::fmt::Debug;
+use core::fmt::Debug;
 use yarnspinner_core::prelude::*;
 
 mod context;

--- a/crates/runtime/src/analyser/diagnosis.rs
+++ b/crates/runtime/src/analyser/diagnosis.rs
@@ -4,7 +4,7 @@
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
 use core::fmt::{Display, Formatter};
-use std::iter;
+use core::iter;
 
 /// A result of analysing a compiled Yarn program with [`Dialogue::analyse`]. Created by the [`CompiledProgramAnalyser`]s used in the given [`Context`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/runtime/src/command.rs
+++ b/crates/runtime/src/command.rs
@@ -87,7 +87,7 @@ fn split_command_text(input: &str) -> Vec<String> {
                     // We've reached the end of a run of visible
                     // characters. Add this run to the result list and
                     // prepare for the next one.
-                    results.push(std::mem::take(&mut current_component));
+                    results.push(core::mem::take(&mut current_component));
                 } else {
                     // We encountered a whitespace character, but
                     // didn't have any characters queued up. Skip this
@@ -133,7 +133,7 @@ fn split_command_text(input: &str) -> Vec<String> {
                         }
                     }
                 }
-                results.push(std::mem::take(&mut current_component));
+                results.push(core::mem::take(&mut current_component));
             }
             _ => {
                 current_component.push(char);

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -4,10 +4,10 @@ use crate::markup::{DialogueTextProcessor, LineParser, MarkupParseError};
 use crate::prelude::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
+use core::error::Error;
+use core::fmt::{self, Debug, Display};
 use log::error;
 use std::collections::HashMap;
-use std::error::Error;
-use std::fmt::{self, Debug, Display};
 use yarnspinner_core::prelude::*;
 
 /// Co-ordinates the execution of Yarn programs.
@@ -20,7 +20,7 @@ pub struct Dialogue {
 }
 
 #[allow(missing_docs)]
-pub type Result<T> = std::result::Result<T, DialogueError>;
+pub type Result<T> = core::result::Result<T, DialogueError>;
 
 #[allow(missing_docs)]
 #[derive(Debug)]
@@ -166,7 +166,7 @@ impl Dialogue {
     ) -> Option<Language> {
         let language_code = language_code.into();
         self.vm.set_language_code(language_code.clone());
-        std::mem::replace(&mut self.language_code, language_code)
+        core::mem::replace(&mut self.language_code, language_code)
     }
 
     /// Gets the [`Library`] that this Dialogue uses to locate functions.

--- a/crates/runtime/src/dialogue_option.rs
+++ b/crates/runtime/src/dialogue_option.rs
@@ -1,7 +1,7 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
 
 use crate::prelude::*;
-use std::fmt::Display;
+use core::fmt::Display;
 
 /// An option to be presented to the user.
 #[derive(Debug, Clone, PartialEq)]
@@ -52,7 +52,7 @@ pub struct DialogueOption {
 pub struct OptionId(pub usize);
 
 impl Display for OptionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/crates/runtime/src/language.rs
+++ b/crates/runtime/src/language.rs
@@ -18,7 +18,7 @@ impl Language {
 }
 
 impl Display for Language {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/crates/runtime/src/markup/line_parser.rs
+++ b/crates/runtime/src/markup/line_parser.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, VecDeque};
 use unicode_normalization::UnicodeNormalization;
 use unicode_segmentation::UnicodeSegmentation;
 
-pub type Result<T> = std::result::Result<T, MarkupParseError>;
+pub type Result<T> = core::result::Result<T, MarkupParseError>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "bevy", derive(Reflect))]

--- a/crates/runtime/src/markup/markup_parse_error.rs
+++ b/crates/runtime/src/markup/markup_parse_error.rs
@@ -1,8 +1,8 @@
 use crate::markup::TRIM_WHITESPACE_PROPERTY;
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
-use std::error::Error;
-use std::fmt;
+use core::error::Error;
+use core::fmt;
 
 #[allow(missing_docs)]
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/crates/runtime/src/markup/parsed_markup.rs
+++ b/crates/runtime/src/markup/parsed_markup.rs
@@ -2,7 +2,7 @@
 
 pub use self::{markup_attribute::*, markup_value::*};
 pub(crate) use self::{markup_attribute_marker::*, tag_type::*};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 mod markup_attribute;
 mod markup_attribute_marker;

--- a/crates/runtime/src/markup/parsed_markup/markup_attribute.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_attribute.rs
@@ -54,7 +54,7 @@ impl MarkupAttribute {
 }
 
 impl Display for MarkupAttribute {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let properties = (!self.properties.is_empty())
             .then(|| format!(", {} properties", self.properties.len()))
             .unwrap_or_default();

--- a/crates/runtime/src/markup/parsed_markup/markup_value.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_value.rs
@@ -41,7 +41,7 @@ impl MarkupValue {
 }
 
 impl Display for MarkupValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             MarkupValue::Integer(i) => write!(f, "{i}"),
             MarkupValue::Float(fl) => write!(f, "{fl}"),

--- a/crates/runtime/src/text_provider.rs
+++ b/crates/runtime/src/text_provider.rs
@@ -1,9 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
 use crate::prelude::Language;
+use core::any::Any;
+use core::fmt::Debug;
 use log::error;
-use std::any::Any;
 use std::collections::HashMap;
-use std::fmt::Debug;
 use yarnspinner_core::prelude::*;
 
 /// A trait for providing text to a [`Dialogue`](crate::prelude::Dialogue). The default implementation is [`StringTableTextProvider`], which keeps the

--- a/crates/runtime/src/variable_storage.rs
+++ b/crates/runtime/src/variable_storage.rs
@@ -1,13 +1,13 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
-use std::any::Any;
+use core::any::Any;
+use core::error::Error;
+use core::fmt::{self, Debug, Display};
 use std::collections::HashMap;
-use std::error::Error;
-use std::fmt::{self, Debug, Display};
 use std::sync::{Arc, RwLock};
 use yarnspinner_core::prelude::*;
 
 #[allow(missing_docs)]
-pub type Result<T> = std::result::Result<T, VariableStorageError>;
+pub type Result<T> = core::result::Result<T, VariableStorageError>;
 
 /// Provides a mechanism for storing and retrieving instances
 /// of the [`YarnValue`] type.

--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -9,8 +9,8 @@ use crate::prelude::*;
 use crate::Result;
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
+use core::fmt::Debug;
 use log::*;
-use std::fmt::Debug;
 use yarnspinner_core::prelude::OpCode;
 use yarnspinner_core::prelude::*;
 
@@ -97,7 +97,7 @@ impl VirtualMachine {
     pub(crate) fn stop(&mut self) -> Vec<DialogueEvent> {
         self.set_execution_state(ExecutionState::Stopped);
         self.batched_events.push(DialogueEvent::DialogueComplete);
-        std::mem::take(&mut self.batched_events)
+        core::mem::take(&mut self.batched_events)
     }
 
     pub(crate) fn set_node(&mut self, node_name: impl Into<String>) -> Result<()> {
@@ -211,7 +211,7 @@ impl VirtualMachine {
             self.batched_events.push(DialogueEvent::DialogueComplete);
             debug!("Run complete.");
         }
-        Ok(std::mem::take(&mut self.batched_events))
+        Ok(core::mem::take(&mut self.batched_events))
     }
 
     pub(crate) fn parse_markup(&mut self, line: &str) -> crate::markup::Result<ParsedMarkup> {

--- a/crates/runtime/src/virtual_machine/state.rs
+++ b/crates/runtime/src/virtual_machine/state.rs
@@ -1,7 +1,7 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/VirtualMachine.cs>, which we split into multiple files
 
 use crate::prelude::*;
-use std::fmt::Debug;
+use core::fmt::Debug;
 use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Default)]


### PR DESCRIPTION
Swap out std types when there's an alternative core type

progress toward #232 