### PR TITLE
no-std support for runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5816,6 +5816,7 @@ name = "yarnspinner_runtime"
 version = "0.5.0"
 dependencies = [
  "bevy",
+ "bevy_platform",
  "fixed_decimal",
  "icu_locid",
  "icu_plurals",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5761,6 +5761,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "bevy",
+ "bevy_platform",
  "log",
  "regex",
  "yarnspinner_compiler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,8 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite3d"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/extrawurst/bevy_sprite3d.git?branch=bevy-0.16#e8e03a4c079e9180f971c5dbc23dce19e76dc9df"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab6a643739da6d576c28d7e20f78aa4dc00406eefcf92f1a5e1f30fad367079"
 dependencies = [
  "bevy",
 ]

--- a/crates/bevy_plugin/src/dialogue_runner/localized_line.rs
+++ b/crates/bevy_plugin/src/dialogue_runner/localized_line.rs
@@ -34,7 +34,7 @@ impl LocalizedLine {
     /// ## Examples
     /// When there is a name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy::platform::collections::HashMap;
     /// # use bevy_yarnspinner::prelude::*;
     /// # let line = LocalizedLine {
     /// #    id: "line".into(),
@@ -55,7 +55,7 @@ impl LocalizedLine {
     ///
     /// When there is no name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy::platform::collections::HashMap;
     /// # use bevy_yarnspinner::prelude::*;
     /// # let line = LocalizedLine {
     /// #    id: "line".into(),
@@ -87,7 +87,7 @@ impl LocalizedLine {
     /// ## Examples
     /// When there is a name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy::platform::collections::HashMap;
     /// # use bevy_yarnspinner::prelude::*;
     /// # let line = LocalizedLine {
     /// #    id: "line".into(),
@@ -108,7 +108,7 @@ impl LocalizedLine {
     ///
     /// When there is no name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy::platform::collections::HashMap;
     /// # use bevy_yarnspinner::prelude::*;
     /// # let line = LocalizedLine {
     /// #    id: "line".into(),

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -10,7 +10,14 @@ license = "MIT OR Apache-2.0"
 description = "Runtime / VM for Yarn Spinner for Rust, the friendly tool for writing game dialogue"
 
 [features]
-default = []
+default = ["std"]
+std = [
+    "icu_locid/std",
+    "icu_plurals/std",
+    "fixed_decimal/ryu",
+    "unicode-normalization/std",
+    "bevy_platform/std",
+]
 serde = [
     "dep:serde",
     "bevy?/serialize",
@@ -21,13 +28,21 @@ bevy = ["dep:bevy", "yarnspinner_core/bevy"]
 
 [dependencies]
 yarnspinner_core = { path = "../core", version = "0.5.0" }
-unicode-normalization = "0.1"
+unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = "1"
 log = "0.4"
-icu_plurals = { version = "1.5", features = ["std"] }
-icu_locid = { version = "1.5", features = ["std"] }
-fixed_decimal = { version = "0.5", features = ["ryu", "std"] }
+icu_plurals = { version = "1.5", features = ["default"] }
+icu_locid = { version = "1.5", default-features = false }
+fixed_decimal = { version = "0.5", default-features = false, features = [
+    "ryu",
+] }
 once_cell = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 bevy = { version = "0.16.0", default-features = false, optional = true }
+bevy_platform = { version = "0.16.0", features = ["alloc"] }
+
+[lints.clippy]
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -23,6 +23,7 @@ serde = [
     "bevy?/serialize",
     "yarnspinner_core/serde",
     "icu_locid/serde",
+    "bevy_platform/serialize",
 ]
 bevy = ["dep:bevy", "yarnspinner_core/bevy"]
 

--- a/crates/runtime/src/analyser.rs
+++ b/crates/runtime/src/analyser.rs
@@ -2,8 +2,8 @@
 
 pub(crate) use self::default_analysers::*;
 pub use self::{context::*, diagnosis::*};
+use crate::prelude::*;
 use core::fmt::Debug;
-use yarnspinner_core::prelude::*;
 
 mod context;
 pub(crate) mod default_analysers;

--- a/crates/runtime/src/analyser/context.rs
+++ b/crates/runtime/src/analyser/context.rs
@@ -11,7 +11,7 @@ pub struct Context(Vec<Box<dyn CompiledProgramAnalyser>>);
 
 impl IntoIterator for Context {
     type Item = Box<dyn CompiledProgramAnalyser>;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/crates/runtime/src/analyser/default_analysers/unused_variable_checker.rs
+++ b/crates/runtime/src/analyser/default_analysers/unused_variable_checker.rs
@@ -3,7 +3,6 @@
 
 use crate::prelude::*;
 use bevy_platform::collections::HashSet;
-use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Default)]
 pub(crate) struct UnusedVariableChecker {

--- a/crates/runtime/src/analyser/default_analysers/unused_variable_checker.rs
+++ b/crates/runtime/src/analyser/default_analysers/unused_variable_checker.rs
@@ -2,7 +2,7 @@
 //! which was split into multiple files.
 
 use crate::prelude::*;
-use std::collections::HashSet;
+use bevy_platform::collections::HashSet;
 use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Default)]

--- a/crates/runtime/src/analyser/default_analysers/variable_lister.rs
+++ b/crates/runtime/src/analyser/default_analysers/variable_lister.rs
@@ -3,7 +3,6 @@
 
 use crate::prelude::*;
 use bevy_platform::collections::HashSet;
-use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Default)]
 pub(crate) struct VariableLister {

--- a/crates/runtime/src/analyser/default_analysers/variable_lister.rs
+++ b/crates/runtime/src/analyser/default_analysers/variable_lister.rs
@@ -2,7 +2,7 @@
 //! which was split into multiple files.
 
 use crate::prelude::*;
-use std::collections::HashSet;
+use bevy_platform::collections::HashSet;
 use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Default)]

--- a/crates/runtime/src/analyser/diagnosis.rs
+++ b/crates/runtime/src/analyser/diagnosis.rs
@@ -1,7 +1,6 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Analyser.cs>,
 //! which was split into multiple files.
 
-#[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
 use core::fmt::{Display, Formatter};
 use core::iter;

--- a/crates/runtime/src/command.rs
+++ b/crates/runtime/src/command.rs
@@ -4,9 +4,7 @@
 //! The original delegates command parsing to the Unity plugin, but we think it's foundational enough to do it directly in the runtime.
 
 use crate::markup::normalize;
-#[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
-use yarnspinner_core::prelude::YarnValue;
 
 /// A custom command found in a Yarn file within the `<<` and `>>` characters.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -4,10 +4,10 @@ use crate::markup::{DialogueTextProcessor, LineParser, MarkupParseError};
 use crate::prelude::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
+use bevy_platform::collections::HashMap;
 use core::error::Error;
 use core::fmt::{self, Debug, Display};
 use log::error;
-use std::collections::HashMap;
 use yarnspinner_core::prelude::*;
 
 /// Co-ordinates the execution of Yarn programs.

--- a/crates/runtime/src/events.rs
+++ b/crates/runtime/src/events.rs
@@ -6,7 +6,6 @@
 //! - Additional newtypes were introduced for strings.
 
 use crate::prelude::*;
-use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Reflect))]

--- a/crates/runtime/src/language.rs
+++ b/crates/runtime/src/language.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
 use core::fmt::Display;
 use icu_locid::LanguageIdentifier;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -6,6 +6,9 @@
 //! - If you wish to write an adapter crate for an engine yourself, use the [`yarnspinner`](https://crates.io/crates/yarnspinner) crate.
 
 #![warn(missing_docs, missing_debug_implementations)]
+
+extern crate alloc;
+
 mod analyser;
 mod command;
 mod dialogue;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -6,8 +6,12 @@
 //! - If you wish to write an adapter crate for an engine yourself, use the [`yarnspinner`](https://crates.io/crates/yarnspinner) crate.
 
 #![warn(missing_docs, missing_debug_implementations)]
+#![no_std]
 
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 mod analyser;
 mod command;
@@ -24,8 +28,18 @@ mod virtual_machine;
 
 pub use dialogue::Result;
 
+/// Everything you need to get starting using the Yarn Spinner runtime.
 pub mod prelude {
-    //! Everything you need to get starting using the Yarn Spinner runtime.
+    // Re-export alloc types for internal use only
+    pub(crate) use alloc::{
+        borrow::ToOwned,
+        boxed::Box,
+        format,
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
+
     pub use crate::{
         analyser::*,
         command::*,

--- a/crates/runtime/src/line.rs
+++ b/crates/runtime/src/line.rs
@@ -54,7 +54,7 @@ impl Line {
     /// ## Examples
     /// When there is a name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy_platform::collections::HashMap;
     /// # use yarnspinner_core::prelude::*;
     /// # use yarnspinner_runtime::markup::*;
     /// # use yarnspinner_runtime::prelude::*;
@@ -75,7 +75,7 @@ impl Line {
     ///
     /// When there is no name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy_platform::collections::HashMap;
     /// # use yarnspinner_core::prelude::*;
     /// # use yarnspinner_runtime::markup::*;
     /// # use yarnspinner_runtime::prelude::*;
@@ -106,7 +106,7 @@ impl Line {
     /// ## Examples
     /// When there is a name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy_platform::collections::HashMap;
     /// # use yarnspinner_core::prelude::*;
     /// # use yarnspinner_runtime::markup::*;
     /// # use yarnspinner_runtime::prelude::*;
@@ -127,7 +127,7 @@ impl Line {
     ///
     /// When there is no name:
     /// ```rust
-    /// # use std::collections::HashMap;
+    /// # use bevy_platform::collections::HashMap;
     /// # use yarnspinner_core::prelude::*;
     /// # use yarnspinner_runtime::markup::*;
     /// # use yarnspinner_runtime::prelude::*;

--- a/crates/runtime/src/markup.rs
+++ b/crates/runtime/src/markup.rs
@@ -11,7 +11,7 @@ mod markup_parse_error;
 mod parsed_markup;
 
 pub use self::line_parser::{
-    CHARACTER_ATTRIBUTE, CHARACTER_ATTRIBUTE_NAME_PROPERTY, TRIM_WHITESPACE_PROPERTY,
+    Result, CHARACTER_ATTRIBUTE, CHARACTER_ATTRIBUTE_NAME_PROPERTY, TRIM_WHITESPACE_PROPERTY,
 };
 pub(crate) use self::{attribute_marker_processor::*, line_parser::*};
 pub use self::{markup_parse_error::*, parsed_markup::*};
@@ -20,7 +20,7 @@ pub use self::{markup_parse_error::*, parsed_markup::*};
 mod tests {
     //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Tests/MarkupTests.cs>
     use super::*;
-    use crate::prelude::{Language, Line};
+    use crate::prelude::*;
 
     #[test]
     fn test_markup_parsing() {

--- a/crates/runtime/src/markup/attribute_marker_processor.rs
+++ b/crates/runtime/src/markup/attribute_marker_processor.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use self::{dialogue_text_processor::*, no_markup_text_processor::*};
 use crate::markup::MarkupAttributeMarker;
-use crate::prelude::Language;
+use crate::prelude::*;
 use core::fmt::Debug;
 
 mod dialogue_text_processor;

--- a/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
+++ b/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
@@ -2,8 +2,8 @@
 
 use crate::markup::AttributeMarkerProcessor;
 use crate::prelude::*;
+use bevy_platform::collections::HashSet;
 use icu_plurals::PluralCategory;
-use std::collections::HashSet;
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct DialogueTextProcessor {

--- a/crates/runtime/src/markup/attribute_marker_processor/no_markup_text_processor.rs
+++ b/crates/runtime/src/markup/attribute_marker_processor/no_markup_text_processor.rs
@@ -3,7 +3,7 @@
 use crate::markup::{
     AttributeMarkerProcessor, MarkupAttributeMarker, MarkupValue, REPLACEMENT_MARKER_CONTENTS,
 };
-use crate::prelude::Language;
+use crate::prelude::*;
 
 /// A markup text processor that implements the `[nomarkup]` attribute's behaviour.
 #[derive(Default, Debug, Clone)]

--- a/crates/runtime/src/markup/line_parser.rs
+++ b/crates/runtime/src/markup/line_parser.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 use unicode_normalization::UnicodeNormalization;
 use unicode_segmentation::UnicodeSegmentation;
 
-/// A result type for the [`LineParser`]
+/// A result type for the line parser
 pub type Result<T> = core::result::Result<T, MarkupParseError>;
 
 #[derive(Debug, Clone)]

--- a/crates/runtime/src/markup/line_parser.rs
+++ b/crates/runtime/src/markup/line_parser.rs
@@ -1,14 +1,16 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/YarnSpinner.Markup/LineParser.cs>
 
+use std::collections::VecDeque;
+
 use crate::markup::parsed_markup::ParsedMarkup;
 use crate::markup::{
     AttributeMarkerProcessor, MarkupAttribute, MarkupAttributeMarker, MarkupParseError,
     MarkupValue, NoMarkupTextProcessor, TagType,
 };
 use crate::prelude::*;
+use bevy_platform::collections::HashMap;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::collections::{HashMap, VecDeque};
 use unicode_normalization::UnicodeNormalization;
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/crates/runtime/src/markup/line_parser.rs
+++ b/crates/runtime/src/markup/line_parser.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 use unicode_normalization::UnicodeNormalization;
 use unicode_segmentation::UnicodeSegmentation;
 
+/// A result type for the [`LineParser`]
 pub type Result<T> = core::result::Result<T, MarkupParseError>;
 
 #[derive(Debug, Clone)]

--- a/crates/runtime/src/markup/line_parser.rs
+++ b/crates/runtime/src/markup/line_parser.rs
@@ -1,6 +1,6 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/YarnSpinner.Markup/LineParser.cs>
 
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
 
 use crate::markup::parsed_markup::ParsedMarkup;
 use crate::markup::{

--- a/crates/runtime/src/markup/markup_parse_error.rs
+++ b/crates/runtime/src/markup/markup_parse_error.rs
@@ -1,5 +1,4 @@
 use crate::markup::TRIM_WHITESPACE_PROPERTY;
-#[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
 use core::error::Error;
 use core::fmt;

--- a/crates/runtime/src/markup/parsed_markup.rs
+++ b/crates/runtime/src/markup/parsed_markup.rs
@@ -2,6 +2,7 @@
 
 pub use self::{markup_attribute::*, markup_value::*};
 pub(crate) use self::{markup_attribute_marker::*, tag_type::*};
+use crate::prelude::*;
 use core::fmt::Debug;
 
 mod markup_attribute;

--- a/crates/runtime/src/markup/parsed_markup/markup_attribute.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_attribute.rs
@@ -2,7 +2,6 @@
 //! which was split into multiple files.
 
 use crate::markup::{MarkupAttributeMarker, MarkupValue};
-#[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
 use bevy_platform::collections::HashMap;
 use core::fmt::Display;

--- a/crates/runtime/src/markup/parsed_markup/markup_attribute.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_attribute.rs
@@ -4,8 +4,8 @@
 use crate::markup::{MarkupAttributeMarker, MarkupValue};
 #[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
+use bevy_platform::collections::HashMap;
 use core::fmt::Display;
-use std::collections::HashMap;
 
 /// Represents a range of text in a marked-up string.
 ///

--- a/crates/runtime/src/markup/parsed_markup/markup_attribute_marker.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_attribute_marker.rs
@@ -2,7 +2,7 @@
 //! which was split into multiple files.
 
 use crate::markup::{MarkupValue, TagType};
-use std::collections::HashMap;
+use bevy_platform::collections::HashMap;
 
 /// Represents a marker (e.g. `[a]`) in line of marked up text.
 ///

--- a/crates/runtime/src/markup/parsed_markup/markup_attribute_marker.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_attribute_marker.rs
@@ -2,6 +2,7 @@
 //! which was split into multiple files.
 
 use crate::markup::{MarkupValue, TagType};
+use crate::prelude::*;
 use bevy_platform::collections::HashMap;
 
 /// Represents a marker (e.g. `[a]`) in line of marked up text.

--- a/crates/runtime/src/markup/parsed_markup/markup_value.rs
+++ b/crates/runtime/src/markup/parsed_markup/markup_value.rs
@@ -1,7 +1,6 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/YarnSpinner.Markup/MarkupParseResult.cs>
 //! which was split into multiple files.
 
-#[cfg(any(feature = "bevy", feature = "serde"))]
 use crate::prelude::*;
 use core::fmt::Display;
 

--- a/crates/runtime/src/text_provider.rs
+++ b/crates/runtime/src/text_provider.rs
@@ -1,10 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
-use crate::prelude::Language;
+use crate::prelude::*;
 use bevy_platform::collections::HashMap;
 use core::any::Any;
 use core::fmt::Debug;
 use log::error;
-use yarnspinner_core::prelude::*;
 
 /// A trait for providing text to a [`Dialogue`](crate::prelude::Dialogue). The default implementation is [`StringTableTextProvider`], which keeps the
 /// text for the base language, i.e. the language the Yarn files are written in, and the text for the currently selected translation in memory.

--- a/crates/runtime/src/text_provider.rs
+++ b/crates/runtime/src/text_provider.rs
@@ -1,9 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
 use crate::prelude::Language;
+use bevy_platform::collections::HashMap;
 use core::any::Any;
 use core::fmt::Debug;
 use log::error;
-use std::collections::HashMap;
 use yarnspinner_core::prelude::*;
 
 /// A trait for providing text to a [`Dialogue`](crate::prelude::Dialogue). The default implementation is [`StringTableTextProvider`], which keeps the

--- a/crates/runtime/src/variable_storage.rs
+++ b/crates/runtime/src/variable_storage.rs
@@ -1,9 +1,9 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
+use bevy_platform::collections::HashMap;
+use bevy_platform::sync::{Arc, RwLock};
 use core::any::Any;
 use core::error::Error;
 use core::fmt::{self, Debug, Display};
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 use yarnspinner_core::prelude::*;
 
 #[allow(missing_docs)]

--- a/crates/runtime/src/variable_storage.rs
+++ b/crates/runtime/src/variable_storage.rs
@@ -1,10 +1,10 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/Dialogue.cs>, which we split off into multiple files
+use crate::prelude::*;
 use bevy_platform::collections::HashMap;
 use bevy_platform::sync::{Arc, RwLock};
 use core::any::Any;
 use core::error::Error;
 use core::fmt::{self, Debug, Display};
-use yarnspinner_core::prelude::*;
 
 #[allow(missing_docs)]
 pub type Result<T> = core::result::Result<T, VariableStorageError>;

--- a/crates/runtime/src/virtual_machine.rs
+++ b/crates/runtime/src/virtual_machine.rs
@@ -11,8 +11,6 @@ use crate::Result;
 use bevy::prelude::World;
 use core::fmt::Debug;
 use log::*;
-use yarnspinner_core::prelude::OpCode;
-use yarnspinner_core::prelude::*;
 
 mod execution_state;
 mod state;

--- a/crates/runtime/src/virtual_machine/execution_state.rs
+++ b/crates/runtime/src/virtual_machine/execution_state.rs
@@ -1,8 +1,5 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/VirtualMachine.cs>, which we split into multiple files
 
-#[cfg(any(feature = "bevy", feature = "serde"))]
-use crate::prelude::*;
-
 /// ## Implementation notes
 /// Does not contain `DeliveringContent` since that that state would be used to indicate
 /// that a handler is currently running, which we don't have.

--- a/crates/runtime/src/virtual_machine/execution_state.rs
+++ b/crates/runtime/src/virtual_machine/execution_state.rs
@@ -1,5 +1,8 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/VirtualMachine.cs>, which we split into multiple files
 
+#[allow(unused_imports)]
+use crate::prelude::*;
+
 /// ## Implementation notes
 /// Does not contain `DeliveringContent` since that that state would be used to indicate
 /// that a handler is currently running, which we don't have.

--- a/crates/runtime/src/virtual_machine/execution_state.rs
+++ b/crates/runtime/src/virtual_machine/execution_state.rs
@@ -1,6 +1,6 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner/VirtualMachine.cs>, which we split into multiple files
 
-#[allow(unused_imports)]
+#[allow(unused_imports)] // Used in the case of no default, `serde` only feature
 use crate::prelude::*;
 
 /// ## Implementation notes

--- a/crates/runtime/src/virtual_machine/state.rs
+++ b/crates/runtime/src/virtual_machine/state.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 use core::fmt::Debug;
-use yarnspinner_core::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "bevy", derive(Reflect))]

--- a/crates/yarnspinner/Cargo.toml
+++ b/crates/yarnspinner/Cargo.toml
@@ -37,3 +37,4 @@ bevy = { version = "0.16.0", default-features = false, optional = true }
 [dev-dependencies]
 regex = "1"
 anyhow = "1"
+bevy_platform = "0.16.0"

--- a/crates/yarnspinner/tests/dialogue_tests.rs
+++ b/crates/yarnspinner/tests/dialogue_tests.rs
@@ -175,9 +175,7 @@ fn test_getting_headers() {
     test_base = test_base.with_program(result.program.unwrap());
     let dialogue = &test_base.dialogue;
 
-    let headers = dialogue
-        .get_headers_for_node("LearnMore")
-        .unwrap();
+    let headers = dialogue.get_headers_for_node("LearnMore").unwrap();
 
     let mut expected_headers = HashMap::default();
     expected_headers.insert("title".to_string(), "LearnMore".to_string());

--- a/crates/yarnspinner/tests/dialogue_tests.rs
+++ b/crates/yarnspinner/tests/dialogue_tests.rs
@@ -5,7 +5,6 @@
 
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
-use std::collections::HashMap;
 use test_base::prelude::*;
 use yarnspinner::compiler::*;
 use yarnspinner::runtime::*;
@@ -175,15 +174,23 @@ fn test_getting_headers() {
     test_base = test_base.with_program(result.program.unwrap());
     let dialogue = &test_base.dialogue;
 
-    let headers = dialogue.get_headers_for_node("LearnMore").unwrap();
+    let mut headers = dialogue
+        .get_headers_for_node("LearnMore")
+        .unwrap()
+        .into_iter()
+        .collect::<Vec<_>>();
 
-    let mut expected_headers = HashMap::default();
-    expected_headers.insert("title".to_string(), "LearnMore".to_string());
-    expected_headers.insert("tags".to_string(), "rawText".to_string());
-    expected_headers.insert("colorID".to_string(), "0".to_string());
-    expected_headers.insert("position".to_string(), "763,472".to_string());
+    headers.sort();
 
-    assert_eq!(headers, expected_headers);
+    let expected_headers = [
+        ("title", "LearnMore"),
+        ("tags", "rawText"),
+        ("colorID", "0"),
+        ("position", "763,472"),
+    ]
+    .map(|(k, v)| (k.to_string(), v.to_string()));
+
+    assert_eq!(&headers, &expected_headers);
 }
 
 /// ## Implementation note

--- a/crates/yarnspinner/tests/dialogue_tests.rs
+++ b/crates/yarnspinner/tests/dialogue_tests.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "bevy")]
 use bevy::prelude::World;
+use bevy_platform::collections::HashMap;
 use test_base::prelude::*;
 use yarnspinner::compiler::*;
 use yarnspinner::runtime::*;
@@ -174,23 +175,17 @@ fn test_getting_headers() {
     test_base = test_base.with_program(result.program.unwrap());
     let dialogue = &test_base.dialogue;
 
-    let mut headers = dialogue
+    let headers = dialogue
         .get_headers_for_node("LearnMore")
-        .unwrap()
-        .into_iter()
-        .collect::<Vec<_>>();
+        .unwrap();
 
-    headers.sort();
+    let mut expected_headers = HashMap::default();
+    expected_headers.insert("title".to_string(), "LearnMore".to_string());
+    expected_headers.insert("tags".to_string(), "rawText".to_string());
+    expected_headers.insert("colorID".to_string(), "0".to_string());
+    expected_headers.insert("position".to_string(), "763,472".to_string());
 
-    let expected_headers = [
-        ("title", "LearnMore"),
-        ("tags", "rawText"),
-        ("colorID", "0"),
-        ("position", "763,472"),
-    ]
-    .map(|(k, v)| (k.to_string(), v.to_string()));
-
-    assert_eq!(&headers, &expected_headers);
+    assert_eq!(headers, expected_headers);
 }
 
 /// ## Implementation note

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT OR Apache-2.0"
 bevy = { version = "0.16.0" }
 bevy_yarnspinner = { path = "../crates/bevy_plugin", version = "0.5.0" }
 bevy_yarnspinner_example_dialogue_view = { path = "../crates/example_dialogue_view", version = "0.5.0" }
-bevy_sprite3d = { version = "5.0.0-rc.1", git = "https://github.com/extrawurst/bevy_sprite3d.git", branch = "bevy-0.16" }
+bevy_sprite3d = { version = "5.0.0" }

--- a/examples/yarnspinner_without_bevy/src/lib.rs
+++ b/examples/yarnspinner_without_bevy/src/lib.rs
@@ -53,8 +53,8 @@ impl TuiDialogueRunner {
 
         // One of the outputs of compiling is a string table, containing all of the
         // text (and associated metadata) for our dialogue.
-        let mut base_language_string_table = HashMap::default();
-        let mut metadata = HashMap::default();
+        let mut base_language_string_table = HashMap::<LineId, String>::default();
+        let mut metadata = HashMap::<LineId, Vec<String>>::default();
 
         for (k, v) in compilation.string_table {
             base_language_string_table.insert(k.clone(), v.text);


### PR DESCRIPTION
Replaces all of our collection types with bevy_platform or alloc where applicable.

Also creates and uses the std flag

This is a bit of a breaking change because the external api for creating lines now requires hashbrown or bevy_platform