### PR TITLE
put "line:" into const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ dependencies = [
  "tempfile",
  "variadics_please",
  "yarnspinner",
+ "yarnspinner_internal_shared",
 ]
 
 [[package]]
@@ -6457,6 +6458,7 @@ dependencies = [
  "regex",
  "serde",
  "yarnspinner_core",
+ "yarnspinner_internal_shared",
 ]
 
 [[package]]
@@ -6481,6 +6483,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "yarnspinner_internal_shared"
+version = "0.1.0"
+
+[[package]]
 name = "yarnspinner_runtime"
 version = "0.6.1"
 dependencies = [
@@ -6496,6 +6502,7 @@ dependencies = [
  "unicode-normalization",
  "unicode-segmentation",
  "yarnspinner_core",
+ "yarnspinner_internal_shared",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/compiler",
     "crates/core",
     "crates/codegen",
+    "crates/internal_shared",
     "demo",
     "examples/bevy_yarnspinner",
     "examples/yarnspinner_without_bevy",

--- a/crates/bevy_plugin/Cargo.toml
+++ b/crates/bevy_plugin/Cargo.toml
@@ -20,6 +20,7 @@ audio_assets = ["bevy/bevy_audio", "bevy/vorbis"]
 anyhow = "1"
 csv = "1"
 serde = { version = "1", features = ["derive"] }
+yarnspinner_internal_shared = { path = "../internal_shared", version = "0.1.0" }
 yarnspinner = { path = "../yarnspinner", features = [
     "bevy",
     "serde",

--- a/crates/bevy_plugin/src/lib.rs
+++ b/crates/bevy_plugin/src/lib.rs
@@ -152,6 +152,7 @@ pub mod prelude {
         VariableStorage, YarnFn, YarnLibrary, YarnValue,
     };
     pub(crate) type SystemResult = anyhow::Result<()>;
+    pub(crate) use yarnspinner_internal_shared::prelude::*;
 }
 
 pub use crate::commands::{TaskFinishedIndicator, UntypedYarnCommand};

--- a/crates/bevy_plugin/src/line_provider/asset_provider/file_extension_asset_provider_plugin.rs
+++ b/crates/bevy_plugin/src/line_provider/asset_provider/file_extension_asset_provider_plugin.rs
@@ -184,7 +184,7 @@ impl AssetProvider for FileExtensionAssetProvider {
             if let Some(localizations) = self.localizations.as_ref() {
                 if let Some(localization) = localizations.supported_localization(language) {
                     let dir = localization.assets_sub_folder.as_path();
-                    let file_name_without_extension = line.id.0.trim_start_matches("line:");
+                    let file_name_without_extension = line.id.0.trim_start_matches(LINE_ID_PREFIX);
                     let assets = self
                         .file_extensions
                         .iter()
@@ -221,8 +221,10 @@ impl FileExtensionAssetProvider {
                     };
                     for line_id in self.line_ids.iter() {
                         for extension in self.file_extensions.values().flatten() {
-                            let file_name =
-                                format!("{}.{extension}", line_id.0.trim_start_matches("line:"));
+                            let file_name = format!(
+                                "{}.{extension}",
+                                line_id.0.trim_start_matches(LINE_ID_PREFIX)
+                            );
                             let path = dir.join(file_name);
                             let asset_path = path.to_string_lossy().replace('\\', "/");
                             let handle = asset_server.load_untyped(asset_path);

--- a/crates/bevy_plugin/src/localization/strings_file/asset.rs
+++ b/crates/bevy_plugin/src/localization/strings_file/asset.rs
@@ -310,7 +310,7 @@ fn read_comments(metadata: impl IntoIterator<Item = String>) -> String {
     // Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner-Unity/blob/462c735766a4c4881cd1ef1f15de28c83b2ba0a8/Editor/Importers/YarnProjectImporter.cs#L652>
     let cleaned_metadata: Vec<_> = metadata
         .into_iter()
-        .filter(|metadata| !metadata.starts_with("line:"))
+        .filter(|metadata| !metadata.starts_with(LINE_ID_PREFIX))
         .collect();
     if cleaned_metadata.is_empty() {
         String::new()

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -18,6 +18,7 @@ bevy = ["dep:bevy", "yarnspinner_core/bevy"]
 antlr-rust = "=0.3.0-beta"
 better_any = "=0.2.0"
 regex = "1"
+yarnspinner_internal_shared = { path = "../internal_shared", version = "0.1.0" }
 yarnspinner_core = { path = "../core", version = "0.6.0" }
 annotate-snippets = "0.10"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/compiler/src/compiler/utils.rs
+++ b/crates/compiler/src/compiler/utils.rs
@@ -26,7 +26,7 @@ pub(crate) fn get_line_id_tag<'a>(
                 .as_ref()
                 .expect("Hashtag held no text")
                 .get_text();
-            hashtag_text.starts_with("line:")
+            hashtag_text.starts_with(LINE_ID_PREFIX)
         })
         .cloned()
 }
@@ -74,7 +74,7 @@ pub(crate) fn parse_syntax_tree<'a, 'b: 'a>(
 }
 
 pub(crate) fn get_line_id_for_node_name(name: &str) -> LineId {
-    format!("line:{name}").into()
+    format!("{LINE_ID_PREFIX}{name}").into()
 }
 
 /// Gets the text of the documentation comments that either immediately

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -35,7 +35,6 @@ pub mod prelude {
         listeners::{Diagnostic, DiagnosticSeverity, DiagnosticVec},
         output::*,
     };
-    pub(crate) use yarnspinner_internal_shared::prelude::*;
     pub(crate) use yarnspinner_core::prelude::*;
     pub(crate) use yarnspinner_internal_shared::prelude::*;
 }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -36,4 +36,5 @@ pub mod prelude {
         output::*,
     };
     pub(crate) use yarnspinner_core::prelude::*;
+    pub(crate) use yarnspinner_internal_shared::prelude::*;
 }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -35,6 +35,7 @@ pub mod prelude {
         listeners::{Diagnostic, DiagnosticSeverity, DiagnosticVec},
         output::*,
     };
+    pub(crate) use yarnspinner_internal_shared::prelude::*;
     pub(crate) use yarnspinner_core::prelude::*;
     pub(crate) use yarnspinner_internal_shared::prelude::*;
 }

--- a/crates/compiler/src/listeners/untagged_line_listener.rs
+++ b/crates/compiler/src/listeners/untagged_line_listener.rs
@@ -45,7 +45,7 @@ impl<'input> UntaggedLineListener<'input> {
         let mut rng = SmallRng::from_os_rng();
         loop {
             let line: usize = rng.random_range(0..0x1000000);
-            let tag = LineId(format!("line:{line}"));
+            let tag = LineId(format!("{LINE_ID_PREFIX}{line}"));
             if !self.existing_line_tags.contains(&tag) {
                 return tag;
             }
@@ -70,7 +70,7 @@ impl<'input> YarnSpinnerParserListener<'input> for UntaggedLineListener<'input> 
         let texts = get_hashtag_texts(&hashtags);
 
         // And then look for a line ID hashtag.
-        if texts.iter().any(|tag| tag.starts_with("line:")) {
+        if texts.iter().any(|tag| tag.starts_with(LINE_ID_PREFIX)) {
             return;
         }
 

--- a/crates/compiler/src/string_table_manager.rs
+++ b/crates/compiler/src/string_table_manager.rs
@@ -1,6 +1,7 @@
 //! Adapted from <https://github.com/YarnSpinnerTool/YarnSpinner/blob/da39c7195107d8211f21c263e4084f773b84eaff/YarnSpinner.Compiler/StringTableManager.cs>
 
 use crate::output::StringInfo;
+use crate::prelude::*;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use yarnspinner_core::prelude::*;
@@ -33,7 +34,7 @@ impl StringTableManager {
             (line_id, string_info)
         } else {
             let line_id = format!(
-                "line:{}-{}-{}",
+                "{LINE_ID_PREFIX}{}-{}-{}",
                 string_info.file_name,
                 string_info.node_name,
                 self.len()

--- a/crates/internal_shared/Cargo.toml
+++ b/crates/internal_shared/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "yarnspinner_internal_shared"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/crates/internal_shared/Cargo.toml
+++ b/crates/internal_shared/Cargo.toml
@@ -2,6 +2,5 @@
 name = "yarnspinner_internal_shared"
 version = "0.1.0"
 edition = "2021"
-publish = false
 
 [dependencies]

--- a/crates/internal_shared/src/lib.rs
+++ b/crates/internal_shared/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod prelude {
+    pub const LINE_ID_PREFIX: &str = "line:";
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,6 +28,7 @@ serde = [
 bevy = ["dep:bevy", "yarnspinner_core/bevy"]
 
 [dependencies]
+yarnspinner_internal_shared = { path = "../internal_shared", version = "0.1.0" }
 yarnspinner_core = { path = "../core", version = "0.6.0" }
 unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = "1"

--- a/crates/runtime/src/dialogue.rs
+++ b/crates/runtime/src/dialogue.rs
@@ -376,7 +376,7 @@ impl Dialogue {
     #[must_use]
     pub fn get_line_id_for_node(&self, node_name: &str) -> Option<LineId> {
         self.get_node_logging_errors(node_name)
-            .map(|_| format!("line:{node_name}").into())
+            .map(|_| format!("{LINE_ID_PREFIX}{node_name}").into())
     }
 
     /// Returns the tags for the node `node_name`.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -54,4 +54,5 @@ pub mod prelude {
     };
     pub(crate) use crate::{pluralization::*, virtual_machine::*};
     pub(crate) use yarnspinner_core::prelude::*;
+    pub(crate) use yarnspinner_internal_shared::prelude::*;
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -53,7 +53,6 @@ pub mod prelude {
         variable_storage::*,
     };
     pub(crate) use crate::{pluralization::*, virtual_machine::*};
-    pub(crate) use yarnspinner_internal_shared::prelude::*;
     pub(crate) use yarnspinner_core::prelude::*;
     pub(crate) use yarnspinner_internal_shared::prelude::*;
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -53,6 +53,7 @@ pub mod prelude {
         variable_storage::*,
     };
     pub(crate) use crate::{pluralization::*, virtual_machine::*};
+    pub(crate) use yarnspinner_internal_shared::prelude::*;
     pub(crate) use yarnspinner_core::prelude::*;
     pub(crate) use yarnspinner_internal_shared::prelude::*;
 }

--- a/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
+++ b/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
@@ -51,9 +51,9 @@ impl AttributeMarkerProcessor for DialogueTextProcessor {
             .expect("Dialogue locale code is not set. 'plural' and 'ordinal' markers cannot be called unless one is set.");
 
         // Attempt to parse the value as a float, so we can determine its plural class
-        let value_as_float = value
-            .parse::<f32>()
-            .unwrap_or_else(|_| panic!("Error while pluralising line: '{value}' is not a number"));
+        let value_as_float = value.parse::<f32>().unwrap_or_else(|_| {
+            panic!("Error while pluralising {LINE_ID_PREFIX} '{value}' is not a number")
+        });
 
         // Implementation note: no need to fiddle with locales here because ICU already does fallbacks for us.
 

--- a/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
+++ b/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
@@ -51,9 +51,9 @@ impl AttributeMarkerProcessor for DialogueTextProcessor {
             .expect("Dialogue locale code is not set. 'plural' and 'ordinal' markers cannot be called unless one is set.");
 
         // Attempt to parse the value as a float, so we can determine its plural class
-        let value_as_float = value.parse::<f32>().unwrap_or_else(|_| {
-            panic!("Error while pluralising {LINE_ID_PREFIX} '{value}' is not a number")
-        });
+        let value_as_float = value
+            .parse::<f32>()
+            .unwrap_or_else(|_| panic!("Error while pluralising {LINE_ID_PREFIX} '{value}' is not a number"));
 
         // Implementation note: no need to fiddle with locales here because ICU already does fallbacks for us.
 

--- a/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
+++ b/crates/runtime/src/markup/attribute_marker_processor/dialogue_text_processor.rs
@@ -51,9 +51,9 @@ impl AttributeMarkerProcessor for DialogueTextProcessor {
             .expect("Dialogue locale code is not set. 'plural' and 'ordinal' markers cannot be called unless one is set.");
 
         // Attempt to parse the value as a float, so we can determine its plural class
-        let value_as_float = value
-            .parse::<f32>()
-            .unwrap_or_else(|_| panic!("Error while pluralising {LINE_ID_PREFIX} '{value}' is not a number"));
+        let value_as_float = value.parse::<f32>().unwrap_or_else(|_| {
+            panic!("Error while pluralising {LINE_ID_PREFIX} '{value}' is not a number")
+        });
 
         // Implementation note: no need to fiddle with locales here because ICU already does fallbacks for us.
 


### PR DESCRIPTION
Closes https://github.com/YarnSpinnerTool/YarnSpinner-Rust/issues/129

This PR defines a `internal_shared` crate, that holds workspace-wide private constant, such as `"line:"`.

