### PR TITLE
Stop denying warnings in CI aside from lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: --deny warnings
-  RUSTDOCFLAGS: --deny warnings
 
 jobs:
   lint:


### PR DESCRIPTION
As it is now, a warning emitted by clippy will cause multiple CI jobs to fail (ex: https://github.com/YarnSpinnerTool/YarnSpinner-Rust/actions/runs/18300579450/job/52107492698?pr=260).

Ideally, if there is a lint error, the lint job should fail, but this shouldn't cause it to report that the tests failed.