### PR TITLE
Use BEVY_ASSET_ROOT & CARGO_MANIFEST_DIR to load yarn file

### DIFF
--- a/crates/bevy_plugin/src/plugin.rs
+++ b/crates/bevy_plugin/src/plugin.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 use crate::project::{LoadYarnProjectEvent, WatchingForChanges};
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::asset::io::file::FileAssetReader;
 use bevy::prelude::*;
 use std::path::PathBuf;
 pub use yarn_file_source::YarnFileSource;
@@ -244,10 +246,19 @@ impl YarnApp for App {
         self.insert_resource(WatchingForChanges(watching_for_changes))
     }
 
+    #[cfg(target_arch = "wasm32")]
     fn register_asset_root(&mut self) -> &mut Self {
         let asset_plugin = get_asset_plugin(self);
         let path_str = asset_plugin.file_path.clone();
         let path = PathBuf::from(path_str);
+        self.insert_resource(AssetRoot(path))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn register_asset_root(&mut self) -> &mut Self {
+        let asset_plugin = get_asset_plugin(self);
+        let mut path = FileAssetReader::get_base_path();
+        path.push(asset_plugin.file_path.clone());
         self.insert_resource(AssetRoot(path))
     }
 }

--- a/crates/bevy_plugin/src/plugin.rs
+++ b/crates/bevy_plugin/src/plugin.rs
@@ -246,19 +246,15 @@ impl YarnApp for App {
         self.insert_resource(WatchingForChanges(watching_for_changes))
     }
 
-    #[cfg(target_arch = "wasm32")]
     fn register_asset_root(&mut self) -> &mut Self {
         let asset_plugin = get_asset_plugin(self);
         let path_str = asset_plugin.file_path.clone();
-        let path = PathBuf::from(path_str);
-        self.insert_resource(AssetRoot(path))
-    }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    fn register_asset_root(&mut self) -> &mut Self {
-        let asset_plugin = get_asset_plugin(self);
-        let mut path = FileAssetReader::get_base_path();
-        path.push(asset_plugin.file_path.clone());
+        #[cfg(not(target_arch = "wasm32"))]
+        let path = FileAssetReader::get_base_path().join(path_str);
+        #[cfg(target_arch = "wasm32")]
+        let path = PathBuf::from(path_str);
+
         self.insert_resource(AssetRoot(path))
     }
 }


### PR DESCRIPTION
To solve  #271, `register_asser_root` needs to take into account the absolute path that may be included through BEVY_ASSET_ROOT or CARGO_MANIFEST_DIR.

The only way I found to solve this is to use the [FileAssetReader](https://docs.rs/bevy/latest/bevy/asset/io/file/struct.FileAssetReader.html) which is not available in wasm32 builds.

Or we could integrate part of `get_base_path` inside `register_asset_root()` as in:
```rust
fn register_asset_root(&mut self) -> &mut Self {
    let asset_plugin = get_asset_plugin(self);
    let path_str = asset_plugin.file_path.clone();

    let path = if let Ok(manifest_dir) = env::var("BEVY_ASSET_ROOT") {
        let mut root_path = PathBuf::from(manifest_dir);
        root_path.push(path_str);
        root_path
    } else if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
        let mut root_path = PathBuf::from(manifest_dir);
        root_path.push(path_str);
        root_path
    } else {
        PathBuf::from(path_str)
    };

    self.insert_resource(AssetRoot(path))
}
```

However, I'm not an expert in wasm32 build and I don't know if std::env is available there.

Which version do you prefer ?